### PR TITLE
[IMP] password_security: disallow password/login/name similarity

### DIFF
--- a/password_security/README.rst
+++ b/password_security/README.rst
@@ -17,6 +17,7 @@ It contains features such as
 * Password minimum number of uppercase letters
 * Password minimum number of numbers
 * Password minimum number of special characters
+* Password similarity to user's name or login
 
 Configuration
 =============
@@ -34,18 +35,19 @@ Settings & Defaults
 
 These are defined at the company level:
 
-=====================  =======   ===================================================
- Name                  Default   Description                             
-=====================  =======   ===================================================
- password_expiration   60        Days until passwords expire
- password_length       12        Minimum number of characters in password
- password_lower        0         Minimum number of lowercase letter in password
- password_upper        0         Minimum number of uppercase letters in password
- password_numeric      0         Minimum number of number in password
- password_special      0         Minimum number of unique special character in password
- password_history      30        Disallow reuse of this many previous passwords
- password_minimum      24        Amount of hours that must pass until another reset
-=====================  =======   ===================================================
+=================================   =======   =======================================================
+ Name                               Default   Description
+=================================   =======   =======================================================
+ password_expiration                60        Days until passwords expire
+ password_length                    12        Minimum number of characters in password
+ password_lower                     0         Minimum number of lowercase letter in password
+ password_upper                     0         Minimum number of uppercase letters in password
+ password_numeric                   0         Minimum number of number in password
+ password_special                   0         Minimum number of unique special character in password
+ password_history                   30        Disallow reuse of this many previous passwords
+ password_minimum                   24        Amount of hours that must pass until another reset
+ password_not_similar_name_login    True      Disallow password similar to user's name or login
+=================================   =======   =======================================================
 
 Usage
 =====

--- a/password_security/models/res_company.py
+++ b/password_security/models/res_company.py
@@ -49,3 +49,9 @@ class ResCompany(models.Model):
         default=24,
         help='Amount of hours until a user may change password again',
     )
+    password_not_similar_name_login = fields.Boolean(
+        'Disallow passwords similar to name or login',
+        default=True,
+        help='When enabled, users\' passwords can\'t match closely to their '
+             'names or logins.'
+    )

--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -63,7 +63,7 @@ class ResUsers(models.Model):
                 company_id.password_special) + ' character)')
         if company_id.password_not_similar_name_login:
             message.append(
-                '\n* ' + 'Must not be similar to the user\'s login or name.')
+                '\n* Must not be similar user\'s login or name.')
         if message:
             message = [_('Must contain the following:')] + message
         if company_id.password_length:
@@ -76,31 +76,24 @@ class ResUsers(models.Model):
     def _check_password(self, password):
         self._check_password_rules(password)
         self._check_password_history(password)
-        self._check_password_similar_name(password, self.name)
-        self._check_password_similar_login(password, self.login)
+        self._check_password_similarity(password, self.login, self.name)
         return True
 
     @api.multi
-    def _check_password_similar_name(self, password, name):
+    def _check_password_similarity(self, password, login, name):
         self.ensure_one()
         if self.company_id.password_not_similar_name_login:
-            # remove non-alnums from user's name for comparison
-            name_alnum = re.sub(r'[\W_]', '', name)
-            if name_alnum.lower() == password.lower():
-                raise PassError(self.password_match_message())
-        return True
+            password = password.lower()
+            name = name.lower()
 
-    @api.multi
-    def _check_password_similar_login(self, password, login):
-        self.ensure_one()
-        if self.company_id.password_not_similar_name_login:
-            match = re.match(r'([^@]+)(?:@[^@]+)?', login)
-            login_name_only = match.group(1)
-            login_whole = match.group(0)
-            if login_name_only.lower() == password.lower():
+            if password in name or name in password:
                 raise PassError(self.password_match_message())
-            if login_whole.lower() == password.lower():
+
+            login_name = re.match(r'([^@]+)(?:@[^@]+)?', login).group(1)
+
+            if password in login_name or login_name in password:
                 raise PassError(self.password_match_message())
+
         return True
 
     @api.multi

--- a/password_security/views/res_company_view.xml
+++ b/password_security/views/res_company_view.xml
@@ -22,6 +22,7 @@
                         <group string="Extra">
                             <field name="password_length" />
                             <field name="password_history" />
+                            <field name="password_not_similar_name_login"/>
                         </group>
                     </group>
                     <group name="chars_grp" string="Required Characters">


### PR DESCRIPTION
Hi,
I've added some additional functionality to the "password_security" module that provides one more criterion for creating secure passwords - disallows similarity with user's login (whole login or the name part of e-mail address used as a login name) and with user's display name.

If you have any additional suggestions, please, let me know.
Please note that this contribution has been created as a part of my job.

Thank you.

Regards,
Jan Samek, Orgis IT, https://www.orgis.cz/