### PR TITLE
[11.0][auth_brute_force][IMP] Set CIDR configuration & some extra improvements

### DIFF
--- a/auth_brute_force/README.rst
+++ b/auth_brute_force/README.rst
@@ -35,6 +35,9 @@ You can use these configuration parameters that control this addon behavior:
   maximum successive failures allowed for any IP and user combination.
   After hitting the limit, that user and IP combination is banned.
 
+* ``auth_brute_force.check_remote`` defaults to True, and indicates if it
+  it will check the information on http://ip-api.com
+
 Usage
 =====
 

--- a/auth_brute_force/__manifest__.py
+++ b/auth_brute_force/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Authentification - Brute-Force Filter',
-    'version': '11.0.1.1.0',
+    'version': '11.0.1.1.1',
     'category': 'Tools',
     'summary': "Track Authentication Attempts and Prevent Brute-force Attacks",
     'author': "GRAP, "

--- a/auth_brute_force/__manifest__.py
+++ b/auth_brute_force/__manifest__.py
@@ -2,8 +2,8 @@
 # Copyright 2017 Tecnativa - David Vidal
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
-    'name': 'Authentification - Brute-Force Filter',
-    'version': '11.0.1.1.1',
+    'name': 'Authentication - Brute-Force Filter',
+    'version': '11.0.1.2.0',
     'category': 'Tools',
     'summary': "Track Authentication Attempts and Prevent Brute-force Attacks",
     'author': "GRAP, "

--- a/auth_brute_force/models/res_authentication_attempt.py
+++ b/auth_brute_force/models/res_authentication_attempt.py
@@ -37,15 +37,6 @@ class ResAuthenticationAttempt(models.Model):
     whitelisted = fields.Boolean(
         compute="_compute_whitelisted",
     )
-    banned = fields.Boolean(
-        compute="_compute_banned"
-    )
-
-    @api.multi
-    @api.depends('remote', 'login')
-    def _compute_banned(self):
-        for item in self:
-            item.banned = not self._trusted(item.remote, item.login)
 
     @api.multi
     @api.depends('remote')
@@ -193,7 +184,7 @@ class ResAuthenticationAttempt(models.Model):
     @api.multi
     def action_unban(self):
         self.ensure_one()
-        if self.banned:
+        if self.result == 'banned':
             self.write({
                 'result': 'unbanned',
             })

--- a/auth_brute_force/models/res_authentication_attempt.py
+++ b/auth_brute_force/models/res_authentication_attempt.py
@@ -191,11 +191,8 @@ class ResAuthenticationAttempt(models.Model):
     def action_unban(self):
         self.ensure_one()
         if self.banned:
-            self.create({
-                'remote': self.remote,
-                'login': self.login,
+            self.write({
                 'result': 'unbanned',
-
             })
 
     @api.multi

--- a/auth_brute_force/models/res_authentication_attempt.py
+++ b/auth_brute_force/models/res_authentication_attempt.py
@@ -111,12 +111,15 @@ class ResAuthenticationAttempt(models.Model):
             order='create_date desc',
             limit=1,
         )
+
         if last_ok:
             domain += [("create_date", ">", last_ok.create_date)]
         # Count failures since last success, if any
         recent_failures = self.search_count(
-            domain + [("result", "not in",  ["successful", "unbanned"])],
-        )
+            domain + [
+                ("result", "!=", "successful"),
+                ("result", "!=", "unbanned"),
+            ])
         # Did we hit the limit?
         return recent_failures >= limit
 

--- a/auth_brute_force/models/res_authentication_attempt.py
+++ b/auth_brute_force/models/res_authentication_attempt.py
@@ -108,8 +108,7 @@ class ResAuthenticationAttempt(models.Model):
         # Count failures since last success, if any
         recent_failures = self.search_count(
             domain + [
-                ("result", "!=", "successful"),
-                ("result", "!=", "unbanned"),
+                ("result", "not in", ["successful", "unbanned", False]),
             ])
         # Did we hit the limit?
         return recent_failures >= limit

--- a/auth_brute_force/models/res_authentication_attempt.py
+++ b/auth_brute_force/models/res_authentication_attempt.py
@@ -60,7 +60,7 @@ class ResAuthenticationAttempt(models.Model):
                     '%s: %s' % pair for pair in res.items())
 
     @api.model
-    def _check_whitelist(self, ip):
+    def _is_whitelisted(self, ip):
         for whitelist in self._whitelist_remotes():
             try:
                 if (
@@ -75,7 +75,7 @@ class ResAuthenticationAttempt(models.Model):
     @api.multi
     def _compute_whitelisted(self):
         for one in self:
-            one.whitelisted = self._check_whitelist(one.remote)
+            one.whitelisted = self._is_whitelisted(one.remote)
 
     @api.model
     def _hits_limit(self, limit, remote, login=None):
@@ -132,7 +132,7 @@ class ResAuthenticationAttempt(models.Model):
             return True
         get_param = self.env["ir.config_parameter"].sudo().get_param
         # Whitelisted remotes always pass
-        if self._check_whitelist(remote):
+        if self._is_whitelisted(remote):
             return True
         # Check if remote is banned
         limit = int(get_param("auth_brute_force.max_by_ip", 50))

--- a/auth_brute_force/models/res_authentication_attempt.py
+++ b/auth_brute_force/models/res_authentication_attempt.py
@@ -104,7 +104,7 @@ class ResAuthenticationAttempt(models.Model):
         )
 
         if last_ok:
-            domain += [("create_date", ">", last_ok.create_date)]
+            domain += [("id", ">", last_ok.id)]
         # Count failures since last success, if any
         recent_failures = self.search_count(
             domain + [

--- a/auth_brute_force/tests/test_brute_force.py
+++ b/auth_brute_force/tests/test_brute_force.py
@@ -231,7 +231,7 @@ class BruteForceCase(HttpCase):
             self.assertTrue(failed.banned)
             self.assertFailed(failed.whitelisted)
             # Unban
-            failed.action_unbanned()
+            failed.action_unban()
             self.assertFailed(failed.whitelisted)
             self.assertFailed(failed.banned)
         # Try good login, it should work now

--- a/auth_brute_force/tests/test_brute_force.py
+++ b/auth_brute_force/tests/test_brute_force.py
@@ -155,8 +155,85 @@ class BruteForceCase(HttpCase):
                 ("remote", "=", "127.0.0.1"),
             ])
             self.assertEqual(len(banned), 1)
+            self.assertTrue(failed.banned)
+            self.assertFailed(failed.whitelisted)
             # Unban
-            banned.action_whitelist_add()
+            failed.action_whitelist_add()
+            self.assertTrue(failed.whitelisted)
+            self.assertFailed(failed.banned)
+        # Try good login, it should work now
+        response = self.url_open("/web/login", data1, 30)
+        self.assertTrue(response.url.endswith("/web"))
+
+    @skip_unless_addons_installed("web")
+    @mute_logger(*GARBAGE_LOGGERS)
+    def test_web_login_existing_unbanned(self, *args):
+        """Remote is banned with real user on web login form."""
+        data1 = {
+            "login": "admin",
+            "password": "1234",  # Wrong
+        }
+        # Make sure user is logged out
+        self.url_open("/web/session/logout", timeout=30)
+        # Fail 3 times
+        for n in range(3):
+            response = self.url_open("/web/login", data1, 30)
+            # If you fail, you get /web/login again
+            self.assertTrue(
+                response.url.endswith("/web/login"),
+                "Unexpected URL %s" % response.url,
+            )
+        # Admin banned, demo not
+        with self.cursor() as cr:
+            env = self.env(cr)
+            self.assertFalse(
+                env["res.authentication.attempt"]._trusted(
+                    "127.0.0.1",
+                    data1["login"],
+                ),
+            )
+            self.assertTrue(
+                env["res.authentication.attempt"]._trusted(
+                    "127.0.0.1",
+                    "demo",
+                ),
+            )
+        # Now I know the password, but login is rejected too
+        data1["password"] = self.good_password
+        response = self.url_open("/web/login", data1, 30)
+        self.assertTrue(
+            response.url.endswith("/web/login"),
+            "Unexpected URL %s" % response.url,
+        )
+        # IP has been banned, demo user cannot login
+        with self.cursor() as cr:
+            env = self.env(cr)
+            self.assertFalse(
+                env["res.authentication.attempt"]._trusted(
+                    "127.0.0.1",
+                    "demo",
+                ),
+            )
+        # Attempts recorded
+        with self.cursor() as cr:
+            env = self.env(cr)
+            failed = env["res.authentication.attempt"].search([
+                ("result", "=", "failed"),
+                ("login", "=", data1["login"]),
+                ("remote", "=", "127.0.0.1"),
+            ])
+            self.assertEqual(len(failed), 3)
+            banned = env["res.authentication.attempt"].search([
+                ("result", "=", "banned"),
+                ("remote", "=", "127.0.0.1"),
+            ])
+            self.assertEqual(len(banned), 1)
+            self.assertTrue(failed.banned)
+            self.assertFailed(failed.whitelisted)
+            # Unban
+            failed.action_unbanned()
+            self.assertFailed(failed.whitelisted)
+            self.assertFailed(failed.banned)
         # Try good login, it should work now
         response = self.url_open("/web/login", data1, 30)
         self.assertTrue(response.url.endswith("/web"))

--- a/auth_brute_force/views/view.xml
+++ b/auth_brute_force/views/view.xml
@@ -28,7 +28,7 @@
                         name="action_unban"
                         type="object"
                         string="Set to unbanned"
-                        attrs="{'invisible': [('banned', '=', False)]}"
+                        attrs="{'invisible': [('result', '=', 'banned')]}"
                     />
                     <button
                         name="action_whitelist_add"
@@ -50,7 +50,6 @@
                         <field name="login"/>
                         <field name="remote"/>
                         <field name="remote_metadata"/>
-                        <field name="banned" invisible="1"/>
                         <field name="whitelisted" invisible="1"/>
                     </group>
                 </sheet>

--- a/auth_brute_force/views/view.xml
+++ b/auth_brute_force/views/view.xml
@@ -28,7 +28,7 @@
                         name="action_unban"
                         type="object"
                         string="Set to unbanned"
-                        attrs="{'invisible': [('result', '=', 'banned')]}"
+                        attrs="{'invisible': [('result', '!=', 'banned')]}"
                     />
                     <button
                         name="action_whitelist_add"

--- a/auth_brute_force/views/view.xml
+++ b/auth_brute_force/views/view.xml
@@ -10,7 +10,6 @@
             <tree
                 decoration-warning="result == 'failed'"
                 decoration-danger="result == 'banned'"
-                delete="0" create="0"
             >
                 <field name="create_date"/>
                 <field name="remote"/>
@@ -23,10 +22,10 @@
     <record id="view_res_authentication_attempt_form" model="ir.ui.view">
         <field name="model">res.authentication.attempt</field>
         <field name="arch" type="xml">
-            <form create="0" delete="0" edit="0">
+            <form>
                 <header>
                     <button
-                        name="action_unbanned"
+                        name="action_unban"
                         type="object"
                         string="Set to unbanned"
                         attrs="{'invisible': [('banned', '=', False)]}"

--- a/auth_brute_force/views/view.xml
+++ b/auth_brute_force/views/view.xml
@@ -26,6 +26,12 @@
             <form create="0" delete="0" edit="0">
                 <header>
                     <button
+                        name="action_unbanned"
+                        type="object"
+                        string="Set to unbanned"
+                        attrs="{'invisible': [('banned', '=', False)]}"
+                    />
+                    <button
                         name="action_whitelist_add"
                         type="object"
                         string="Add remote to whitelist"
@@ -45,6 +51,7 @@
                         <field name="login"/>
                         <field name="remote"/>
                         <field name="remote_metadata"/>
+                        <field name="banned" invisible="1"/>
                         <field name="whitelisted" invisible="1"/>
                     </group>
                 </sheet>
@@ -70,6 +77,7 @@
                 <filter name="filter_no_success" string="Without Success" domain="[('result','!=', 'successful')]"/>
                 <filter name="filter_banned" string="Banned" domain="[('result','=', 'banned')]"/>
                 <filter name="filter_failed" string="Failed" domain="[('result','=', 'failed')]"/>
+                <filter name="filter_unbanned" string="Unbanned" domain="[('result','=', 'unbanned')]"/>
                 <filter name="filter_successful" string="Successful" domain="[('result','=', 'successful')]"/>
             </search>
         </field>

--- a/auth_brute_force/views/view.xml
+++ b/auth_brute_force/views/view.xml
@@ -10,6 +10,7 @@
             <tree
                 decoration-warning="result == 'failed'"
                 decoration-danger="result == 'banned'"
+                delete="0" create="0"
             >
                 <field name="create_date"/>
                 <field name="remote"/>
@@ -22,7 +23,7 @@
     <record id="view_res_authentication_attempt_form" model="ir.ui.view">
         <field name="model">res.authentication.attempt</field>
         <field name="arch" type="xml">
-            <form>
+            <form create="0" delete="0" edit="0">
                 <header>
                     <button
                         name="action_whitelist_add"


### PR DESCRIPTION
Sets ICDR validation as expected from #22 

Edition and deletion of lines is disallowed and items can be set to unbanned in order to simplify the process. Now, you can set to unbanned in order to reset the counters and you can also maintain all the history.

Fix #22