### PR TITLE
[FIX] password_security: Allow mini-admin to create users

### DIFF
--- a/password_security/__manifest__.py
+++ b/password_security/__manifest__.py
@@ -4,7 +4,7 @@
 
     'name': 'Password Security',
     "summary": "Allow admin to set password security requirements.",
-    'version': '11.0.1.0.1',
+    'version': '11.0.1.1.0',
     'author':
         "LasLabs, "
         "Kaushal Prajapati, "

--- a/password_security/security/res_users_pass_history.xml
+++ b/password_security/security/res_users_pass_history.xml
@@ -17,8 +17,12 @@
         ]</field>
     </record>
 
-    <record id="res_users_pass_history_rule" model="ir.rule">
+    <record id="erp_manager_pass_history_rule" model="ir.rule">
         <field name="name">Res Users Pass History Access</field>
+        <field name="perm_read">0</field>
+        <field name="perm_write">0</field>
+        <field name="perm_create">1</field>
+        <field name="perm_unlink">0</field>
         <field name="model_id"
                ref="password_security.model_res_users_pass_history"/>
         <field name="groups" eval="[(4, ref('base.group_erp_manager'))]"/>

--- a/password_security/security/res_users_pass_history.xml
+++ b/password_security/security/res_users_pass_history.xml
@@ -6,7 +6,7 @@
 -->
 
 <odoo>
-    
+
     <record id="res_users_pass_history_rule" model="ir.rule">
         <field name="name">Res Users Pass History Access</field>
         <field name="model_id"
@@ -14,6 +14,16 @@
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
         <field name="domain_force">[
             ('user_id', '=', user.id)
+        ]</field>
+    </record>
+
+    <record id="res_users_pass_history_rule" model="ir.rule">
+        <field name="name">Res Users Pass History Access</field>
+        <field name="model_id"
+               ref="password_security.model_res_users_pass_history"/>
+        <field name="groups" eval="[(4, ref('base.group_erp_manager'))]"/>
+        <field name="domain_force">[
+            (1, '=', 1)
         ]</field>
     </record>
 

--- a/password_security/tests/test_res_users.py
+++ b/password_security/tests/test_res_users.py
@@ -150,3 +150,11 @@ class TestResUsers(TransactionCase):
         self.assertTrue(self.main_comp.password_special)
         rec_id = self._new_record()
         rec_id._check_password('asdQWE12345_3')
+
+    def test_user_with_admin_rights_can_create_users(self):
+        demo = self.env.ref("base.user_demo")
+        demo.groups_id |= self.env.ref("base.group_erp_manager")
+        self.model_obj.sudo(demo).create({
+            "login": "test1",
+            "name": "test1",
+        })

--- a/password_security/tests/test_res_users.py
+++ b/password_security/tests/test_res_users.py
@@ -154,7 +154,8 @@ class TestResUsers(TransactionCase):
     def test_user_with_admin_rights_can_create_users(self):
         demo = self.env.ref("base.user_demo")
         demo.groups_id |= self.env.ref("base.group_erp_manager")
-        self.model_obj.sudo(demo).create({
+        test1 = self.model_obj.sudo(demo).create({
             "login": "test1",
             "name": "test1",
         })
+        test1.unlink()


### PR DESCRIPTION
In a normal Odoo deployment, somebody in group *Administration / Access Rights* should be able to create users; but if this addon is installed, it gets this error:

    The requested operation cannot be completed due to security restrictions. Please contact your system administrator.

    (Document type: Res Users Password History, Operation: create)

This is now tested and fixed.

@Tecnativa