### PR TITLE
[10.0] auth_keycloak: Fix typo on log in

### DIFF
--- a/auth_keycloak/data/auth_oauth_provider.xml
+++ b/auth_keycloak/data/auth_oauth_provider.xml
@@ -8,6 +8,6 @@
     <field name="validation_endpoint">http://keycloak:8080/auth/realms/master/protocol/openid-connect/token/introspect</field>
     <field name="data_endpoint">http://keycloak:8080/auth/realms/master/protocol/openid-connect/userinfo</field>
     <field name="scope">OAuth2</field>
-    <field name="body">Login with Keycloak</field>
+    <field name="body">Log in with Keycloak</field>
   </record>
 </odoo>


### PR DESCRIPTION
Before :
![screenshot_2018-11-20 keycloak integration - devs guild - confluence c2c](https://user-images.githubusercontent.com/778828/48790567-f06fd580-ecef-11e8-8c4e-58f17e395832.png)

After : 
![image](https://user-images.githubusercontent.com/778828/48790594-fbc30100-ecef-11e8-91aa-5682d487fee3.png)
