### PR TITLE
[FIX] auth_signup_verify_email: Improve signup messages errors

### DIFF
--- a/auth_signup_verify_email/__manifest__.py
+++ b/auth_signup_verify_email/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Verify email at signup",
     "summary": "Force uninvited users to use a good email for signup",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "category": "Authentication",
     "website": "https://github.com/OCA/server-auth",
     "author": "Antiun Ingeniería S.L., "


### PR DESCRIPTION
* When try to login with a not valid email domain it raised a 500 server
  error. Now we shot the proper message "The domain name <domain> does not
  exist."

   Before | After
   --- | ---
   ![image](https://user-images.githubusercontent.com/7593953/49453629-48174200-f7c2-11e8-9173-5925feac1dec.png) | ![image](https://user-images.githubusercontent.com/7593953/49453573-303fbe00-f7c2-11e8-8496-66b5a4fbbab0.png)

* If there is any error we do not have cached when we do the validation then
  we manage it and show the error message to the user instead of 500 server
  error.

* When we try to register with a already exist email it raise "Something went wrong, please try again later or contact us". Instead now show the message as odoo regular signup does: "Another user is already registered using this email address" which is more specific and clear for this case.
