### PR TITLE
[ADD] Add module for authentication with U2F

### DIFF
--- a/auth_u2f/LICENSE.txt
+++ b/auth_u2f/LICENSE.txt
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/auth_u2f/__init__.py
+++ b/auth_u2f/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2017 Joren Van Onder
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+from . import controllers
+from . import models

--- a/auth_u2f/__manifest__.py
+++ b/auth_u2f/__manifest__.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2017 Joren Van Onder
+# Copyright (C) 2019 initOS GmbH
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+{
+    'name': '2nd factor authentication via U2F',
+    'version': '11.0.1.0.0',
+    'author': "Joren Van Onder, "
+              "initOS GmbH, "
+              "Odoo Community Association (OCA)",
+    "summary": "2nd factor authentication via U2F devices",
+    'category': 'Extra Tools',
+    'license': 'LGPL-3',
+    'depends': ['base', 'web'],
+    'data': [
+        'views/u2f_device.xml',
+        'views/u2f_templates.xml',
+        'views/res_users.xml',
+        'security/ir.model.access.csv',
+        'security/auth_u2f_security.xml',
+    ],
+    'external_dependencies': {
+        'python': ['u2flib_server'],
+    },
+    'installable': True,
+}

--- a/auth_u2f/controllers/__init__.py
+++ b/auth_u2f/controllers/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (C) 2017 Joren Van Onder
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+from . import main

--- a/auth_u2f/controllers/main.py
+++ b/auth_u2f/controllers/main.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2017 Joren Van Onder
+# Copyright (C) 2019 initOS GmbH
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+import json
+import werkzeug.utils
+
+from odoo import http
+from odoo.addons.web.controllers.main import Home
+from odoo.http import request
+from odoo.exceptions import AccessDenied
+from ..models.http import U2FAuthenticationError
+
+
+class AuthU2FController(Home):
+    @http.route('/web/u2f/login', type='http', auth='none', sitemap=False)
+    def u2f_login(self, u2f_token_response=None, redirect=None, **kw):
+        user = request.env['res.users'].browse(request.session.uid)
+        user = user.sudo(request.session.uid)
+
+        if not user or not user._u2f_get_device():
+            raise AccessDenied()
+
+        if request.httprequest.method == 'POST':
+            request.session.u2f_token_response = u2f_token_response
+            return http.redirect_with_hash(self._login_redirect(
+                user.id, redirect=redirect))
+        else:
+            login_challenge = user._u2f_get_login_challenge()
+            if not login_challenge:
+                raise AccessDenied()
+
+            request.session.u2f_last_challenge = login_challenge.json
+            return request.render('auth_u2f.login', {
+                'login_data': json.dumps(login_challenge.data_for_client),
+                'redirect': redirect,
+            })
+
+
+class U2FLogin(Home):
+    # necessary because '/web' route has auth="none"
+    @http.route()
+    def web_client(self, s_action=None, **kw):
+        response = super(U2FLogin, self).web_client(s_action=s_action, **kw)
+
+        try:
+            request.env['ir.http']._authenticate()
+        except U2FAuthenticationError:
+            return werkzeug.utils.redirect('/web/u2f/login', 303)
+
+        return response

--- a/auth_u2f/i18n/auth_u2f.pot
+++ b/auth_u2f/i18n/auth_u2f.pot
@@ -1,0 +1,188 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* auth_u2f
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-12-03 23:07+0000\n"
+"PO-Revision-Date: 2017-12-03 23:07+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: auth_u2f
+#. openerp-web
+#: code:addons/auth_u2f/static/src/js/auth_u2f.js:41
+#: code:addons/auth_u2f/static/src/js/auth_u2f_frontend.js:15
+#, python-format
+msgid "A bad request was sent to your browser. This can happen when the URL\n"
+" you're on is not web.base.url or when this page is not served over HTTPS."
+msgstr ""
+
+#. module: auth_u2f
+#. openerp-web
+#: code:addons/auth_u2f/static/src/js/auth_u2f_frontend.js:14
+#, python-format
+msgid "An unknown error occured"
+msgstr ""
+
+#. module: auth_u2f
+#. openerp-web
+#: code:addons/auth_u2f/static/src/js/auth_u2f.js:39
+#: code:addons/auth_u2f/static/src/js/auth_u2f.js:48
+#, python-format
+msgid "An unknown error occurred."
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.model.fields,field_description:auth_u2f.field_u2f_device_create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.model.fields,field_description:auth_u2f.field_u2f_device_create_date
+msgid "Created on"
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.model.fields,field_description:auth_u2f.field_u2f_device_default
+msgid "Default"
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.model.fields,help:auth_u2f.field_u2f_device_default
+msgid "Device used during login."
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.model.fields,field_description:auth_u2f.field_u2f_device_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.model,name:auth_u2f.model_ir_http
+msgid "HTTP routing"
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.model.fields,field_description:auth_u2f.field_u2f_device_id
+msgid "ID"
+msgstr ""
+
+#. module: auth_u2f
+#. openerp-web
+#: code:addons/auth_u2f/static/src/js/auth_u2f.js:58
+#, python-format
+msgid "Insert your security key and tap the button or gold disk."
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.ui.view,arch_db:auth_u2f.login
+msgid "Insert your security key into your computer's USB port. If it has a button, tap it."
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.model.fields,field_description:auth_u2f.field_u2f_device___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.model.fields,field_description:auth_u2f.field_u2f_device_write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.model.fields,field_description:auth_u2f.field_u2f_device_write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.ui.view,arch_db:auth_u2f.u2f_device_form
+msgid "Make default"
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.ui.view,arch_db:auth_u2f.view_users_form_simple_modif_inherit_auth_u2f
+msgid "Manage 2-step verification"
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.model.fields,field_description:auth_u2f.field_u2f_device_name
+msgid "Name"
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.model.fields,field_description:auth_u2f.field_u2f_device_json
+msgid "Scan"
+msgstr ""
+
+#. module: auth_u2f
+#. openerp-web
+#: code:addons/auth_u2f/static/src/js/auth_u2f.js:56
+#, python-format
+msgid "Scanned key."
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.model.fields,help:auth_u2f.field_u2f_device_json
+msgid "Technical data returned by u2flib or the browser"
+msgstr ""
+
+#. module: auth_u2f
+#. openerp-web
+#: code:addons/auth_u2f/static/src/js/auth_u2f.js:46
+#, python-format
+msgid "This device is already registered for this user."
+msgstr ""
+
+#. module: auth_u2f
+#. openerp-web
+#: code:addons/auth_u2f/static/src/js/auth_u2f_frontend.js:18
+#, python-format
+msgid "This device is not registered as the default device for this user."
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.ui.view,arch_db:auth_u2f.view_users_form_inherit_auth_u2f
+msgid "U2F"
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.actions.act_window,name:auth_u2f.action_open_u2f_device_tree
+#: model:ir.model.fields,field_description:auth_u2f.field_res_users_u2f_device_ids
+msgid "U2F devices"
+msgstr ""
+
+#. module: auth_u2f
+#. openerp-web
+#: code:addons/auth_u2f/static/src/js/auth_u2f.js:44
+#: code:addons/auth_u2f/static/src/js/auth_u2f_frontend.js:17
+#, python-format
+msgid "U2F is not supported by this client."
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.ui.view,arch_db:auth_u2f.login
+msgid "Use your security key to sign in"
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.model.fields,field_description:auth_u2f.field_u2f_device_user_id
+msgid "User"
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.model,name:auth_u2f.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: auth_u2f
+#: model:ir.model,name:auth_u2f.model_u2f_device
+msgid "u2f.device"
+msgstr ""
+

--- a/auth_u2f/models/__init__.py
+++ b/auth_u2f/models/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2017 Joren Van Onder
+# Copyright (C) 2019 initOS GmbH
+
+from . import http
+from . import res_users
+from . import u2f_device

--- a/auth_u2f/models/http.py
+++ b/auth_u2f/models/http.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2017 Joren Van Onder
+# Copyright (C) 2019 initOS GmbH
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+import werkzeug.urls
+import werkzeug.utils
+
+from odoo import api, models
+from odoo.http import HttpRequest, request
+
+
+class U2FAuthenticationError(Exception):
+    pass
+
+
+_handle_exception_super = HttpRequest._handle_exception
+
+
+# this is triggered when visiting non-public routes
+def __handle_exception(self, exception):
+    try:
+        return _handle_exception_super(self, exception)
+    except U2FAuthenticationError:
+        redirect = None
+        req = request.httprequest
+        if req.method == 'POST':
+            request.session.save_request_data()
+            redirect = '/web/proxy/post{r.full_path}'.format(r=req)
+        elif not request.params.get('noredirect'):
+            redirect = req.url
+        if redirect:
+            query = werkzeug.urls.url_encode({
+                'redirect': redirect,
+            })
+        return werkzeug.utils.redirect('/web/u2f/login?%s' % query)
+
+
+HttpRequest._handle_exception = __handle_exception
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    @classmethod
+    def _authenticate(cls, auth_method='user'):
+        # super should raise if 1st factor fails
+        res = super(IrHttp, cls)._authenticate(auth_method=auth_method)
+
+        if auth_method == 'user':
+            cr = cls.pool.cursor()
+            try:
+                env = api.Environment(cr, request.session.uid, {})
+                user = env['res.users'].browse(request.session.uid)
+                if user._u2f_get_device():
+                    user.u2f_check_credentials(
+                        request.session.u2f_last_challenge,
+                        request.session.u2f_token_response)
+            finally:
+                cr.close()
+
+        return res

--- a/auth_u2f/models/res_users.py
+++ b/auth_u2f/models/res_users.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2017 Joren Van Onder
+# Copyright (C) 2019 initOS GmbH
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+from odoo import api, fields, models
+from odoo.http import request
+
+import logging
+from .http import U2FAuthenticationError
+
+_logger = logging.getLogger(__name__)
+
+try:
+    import u2flib_server.u2f as u2f
+except ImportError as err:
+    _logger.debug(err)
+
+
+class ResUsers(models.Model):
+    _inherit = 'res.users'
+
+    u2f_device_ids = fields.One2many(
+        'u2f.device', 'user_id', string='U2F devices')
+
+    @api.multi
+    def _u2f_get_device(self):
+        self.ensure_one()
+        default_devices = self.u2f_device_ids.filtered('default')
+        return default_devices[0] if default_devices else False
+
+    @api.model
+    def u2f_get_registration_challenge(self):
+        user = self.env.user
+        icp = self.env['ir.config_parameter'].sudo()
+        baseurl = icp.get_param('web.base.url')
+        already_registered_u2f_devices = user.u2f_device_ids.mapped('json')
+        challenge = u2f.begin_registration(
+            baseurl, already_registered_u2f_devices)
+        request.session.u2f_last_registration_challenge = challenge.json
+
+        return challenge
+
+    @api.multi
+    def _u2f_get_login_challenge(self):
+        self.ensure_one()
+        icp = self.env['ir.config_parameter'].sudo()
+        baseurl = icp.get_param('web.base.url')
+        devices = self._u2f_get_device()
+        if devices:
+            challenge = u2f.begin_authentication(baseurl, [devices.json])
+            return challenge
+        return False
+
+    @api.multi
+    def u2f_check_credentials(self, last_challenge, last_response):
+        self.ensure_one()
+        if self._u2f_get_device():
+            icp = self.env['ir.config_parameter'].sudo()
+            baseurl = icp.get_param('web.base.url')
+            try:
+                if last_challenge and last_response:
+                    device, c, t = u2f.complete_authentication(
+                        last_challenge, last_response, [baseurl])
+                else:
+                    raise U2FAuthenticationError()
+            except Exception:
+                _logger.info(
+                    'Exception during U2F authentication.', exc_info=True)
+                raise U2FAuthenticationError()
+
+            _logger.debug('Successful U2F auth with: %s, %s, %s', device, c, t)
+        return True

--- a/auth_u2f/models/u2f_device.py
+++ b/auth_u2f/models/u2f_device.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2017 Joren Van Onder
+# Copyright (C) 2019 initOS GmbH
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+import logging
+
+from odoo import api, fields, models
+from odoo.http import request
+
+_logger = logging.getLogger(__name__)
+
+try:
+    import u2flib_server.u2f as u2f
+except ImportError as err:
+    _logger.debug(err)
+
+
+class U2FDevice(models.Model):
+    _name = 'u2f.device'
+
+    name = fields.Char(required=True)
+    json = fields.Char(
+        string='Scan', required=True,
+        help='Technical data returned by u2flib or the browser'
+    )
+    user_id = fields.Many2one(
+        'res.users', required=True, readonly=True,
+        default=lambda self: self.env.uid
+    )
+    default = fields.Boolean(help='Device used during login.', readonly=True)
+
+    @api.model
+    def create(self, vals):
+        res = super(U2FDevice, self).create(vals)
+        res._register_device()
+        res.action_make_default()
+        return res
+
+    @api.multi
+    def _register_device(self):
+        icp = self.env['ir.config_parameter'].sudo()
+        baseurl = icp.get_param('web.base.url')
+        for device in self:
+            registration_data, cert = u2f.complete_registration(
+                request.session.u2f_last_registration_challenge,
+                device.json,
+                [baseurl])
+            device.json = registration_data.json
+            del request.session['u2f_last_registration_challenge']
+
+        return True
+
+    @api.multi
+    def action_make_default(self):
+        self.ensure_one()
+        self.user_id.u2f_device_ids.write({'default': False})
+        self.default = True
+
+        return True

--- a/auth_u2f/readme/DESCRIPTION.rst
+++ b/auth_u2f/readme/DESCRIPTION.rst
@@ -1,0 +1,7 @@
+This module adds support for FIDO U2F token based authentication.
+It allows users to enable/disable MFA and manage authentication apps/devices
+via the "Change My Preferences" view and an associated wizard. The server must run HTTPS to
+work properly.
+
+After logging in, users with registered U2F devices are taken to a second screen
+where they have authenticate using device.

--- a/auth_u2f/readme/INSTALL.rst
+++ b/auth_u2f/readme/INSTALL.rst
@@ -1,0 +1,2 @@
+1. Install the U2Flib library using pip: ``pip install python-u2flib-server``
+2. Follow the standard module install process

--- a/auth_u2f/readme/USAGE.rst
+++ b/auth_u2f/readme/USAGE.rst
@@ -1,0 +1,6 @@
+After logging in, set up a U2F device through the user preferences. Click on ‘Manage 2-step verification'
+and create a new device by filling a name and scanning the device.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/251/11.0

--- a/auth_u2f/security/auth_u2f_security.xml
+++ b/auth_u2f/security/auth_u2f_security.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="personal_u2f_devices" model="ir.rule">
+        <field name="name">See only own u2f devices</field>
+        <field name="model_id" ref="model_u2f_device"/>
+        <field name="global" eval="True"/>
+        <field name="domain_force">[('user_id', '=', user.id)]</field>
+    </record>
+</odoo>

--- a/auth_u2f/security/ir.model.access.csv
+++ b/auth_u2f/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_u2f_device_user,access_u2f_device_user,model_u2f_device,base.group_user,1,1,1,1
+access_u2f_device_portal,access_u2f_device_portal,model_u2f_device,base.group_portal,1,1,1,1

--- a/auth_u2f/static/src/js/auth_u2f.js
+++ b/auth_u2f/static/src/js/auth_u2f.js
@@ -1,0 +1,123 @@
+// Copyright (C) 2017 Joren Van Onder
+
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 3 of the
+// License, or (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+// 02110-1301 USA
+
+odoo.define('auth_u2f.u2f', function (require) {
+    'use strict';
+
+    var CrashManager = require('web.CrashManager');
+    var AbstractField = require('web.AbstractField');
+    var core = require('web.core');
+    var registry = require('web.field_registry');
+    var framework = require('web.framework');
+
+    var _t = core._t;
+
+    CrashManager.include({
+        rpc_error: function(error) {
+            if (error.data.name === 'odoo.addons.auth_u2f.models.http.U2FAuthenticationError') {
+                return framework.redirect('/web/u2f/login?redirect=' +
+                                          encodeURIComponent(window.location.href.replace(window.location.origin, '')));
+            } else {
+                return this._super.apply(this, arguments);
+            }
+        },
+    });
+
+    var FieldU2F = AbstractField.extend({
+        className: 'o_field_u2f',
+        supportedFieldTypes: ['char'],
+
+        init: function () {
+            this._super.apply(this, arguments);
+            this.u2f_error_code = false;
+        },
+
+        /**
+         * See https://developers.yubico.com/U2F/Libraries/Client_error_codes.html
+         */
+        _get_error_message: function () {
+            var code = this.u2f_error_code;
+            if (code === 1) {
+                return _t('An unknown error occurred.');
+            } else if (code === 2) {
+                return _t('A bad request was sent to your browser. This can happen when the URL\
+ you\'re on is not web.base.url or when this page is not served over HTTPS.');
+            } else if (code === 3) {
+                return _t('U2F is not supported by this client.');
+            } else if (code === 4) {
+                return _t('This device is already registered for this user.');
+            } else {
+                return _t('An unknown error occurred.');
+            }
+        },
+
+        _render: function () {
+            if (! this.u2f_error_code) {
+                this.$el.css('color', '');
+                if (this.value) {
+                    this.$el.html('<i class="fa fa-check-circle"></i> ' + _t('Scanned key.'));
+                } else {
+                    this.$el.html('<i class="fa fa-spinner fa-spin"></i> ' + _t('Insert your security key and tap the button or gold disk.'));
+                }
+            } else {
+                this.$el.css('color', 'red');
+                this.$el.html('<i class="fa fa-spinner fa-spin"></i> ' + this._get_error_message()
+                              + ' (error code: ' + this.u2f_error_code + ')');
+            }
+
+            return this._super.apply(this, arguments);
+        },
+
+        _renderEdit: function () {
+            var self = this;
+
+            // an error code of 4 (bad request) most likely won't resolve itself, so don't retry
+            if (this.value || this.u2f_error_code === 2) {
+                return;
+            }
+
+            this._rpc({
+                model: 'res.users',
+                method: 'u2f_get_registration_challenge',
+            }).then(function (challenge_data) {
+                // ideally this register request would be cancelled
+                // when this field widget is destroyed but the u2f lib
+                // doesn't seem to be able to do that at the moment.
+                u2f.register(challenge_data.appId,
+                             challenge_data.registerRequests,
+                             challenge_data.registeredKeys.map(JSON.parse),
+                             function (data) {
+                                 if (data.errorCode) {
+                                     self.u2f_error_code = data.errorCode;
+                                     self._render();
+                                 } else {
+                                     self.u2f_error_code = false;
+                                     self._setValue(JSON.stringify(data));
+                                     self._render();
+                                 }
+                             },
+                             0); // timeout of 0 seconds means don't timeout
+            });
+        },
+    });
+
+    registry.add('u2f_scan', FieldU2F);
+
+    return {
+        FieldU2F: FieldU2F,
+    };
+});

--- a/auth_u2f/static/src/js/auth_u2f_frontend.js
+++ b/auth_u2f/static/src/js/auth_u2f_frontend.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2017 Joren Van Onder
+// Copyright (C) 2019 initOS GmbH
+
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 3 of the
+// License, or (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+// 02110-1301 USA
+
+odoo.define('auth_u2f.login', function (require) {
+    'use strict';
+
+    var core = require('web.core');
+    var _t = core._t;
+
+    function u2f_challenge () {
+        var challenge = document.getElementById('u2f_challenge');
+        if (! challenge) {
+            return;
+        }
+
+        var code_to_error_message = {
+            1: _t('An unknown error occured'),
+            2: _t('A bad request was sent to your browser. This can happen when the URL\
+ you\'re on is not web.base.url or when this page is not served over HTTPS.'),
+            3: _t('U2F is not supported by this client.'),
+            4: _t('This device is not registered as the default device for this user.'),
+        };
+
+        var request = JSON.parse(challenge.value);
+        if (request.registeredKeys.length > 0) {
+            u2f.sign(
+                request.appId,
+                request.challenge,
+                request.registeredKeys,
+                function (data) {
+                    if (data.errorCode) {
+                        // just retry if this timed out
+                        if (data.errorCode !== 5) {
+                            $('#error_message').text(code_to_error_message[data.errorCode]);
+                        }
+                        u2f_challenge();
+                    } else {
+                        document.getElementById('u2f_token_response').value = JSON.stringify(data);
+                        document.getElementById('u2f_login_form').submit();
+                    }
+                });
+        }
+    }
+
+    $(document).ready(function () {
+        u2f_challenge();
+    });
+});

--- a/auth_u2f/tests/__init__.py
+++ b/auth_u2f/tests/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (C) 2017 Joren Van Onder
+# Copyright (C) 2019 initOS GmbH
+
+from . import test_device
+from . import test_http
+from . import test_main
+from . import test_users

--- a/auth_u2f/tests/test_device.py
+++ b/auth_u2f/tests/test_device.py
@@ -1,0 +1,91 @@
+# Copyright (C) 2019 initOS GmbH
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+import json
+import logging
+from unittest.mock import MagicMock, patch
+
+from odoo.tests.common import TransactionCase
+
+from .test_main import REQUEST_DATA, RESPONSE_DATA, DEVICE_DATA, BASE_URL
+
+
+_logger = logging.getLogger(__name__)
+
+
+TEST_VALUE = "U2F Test Token"
+MODEL_PATH = 'odoo.addons.auth_u2f.models.u2f_device'
+
+
+class TestDevice(TransactionCase):
+
+    def setUp(self):
+        super(TestDevice, self).setUp()
+
+        self.env['ir.config_parameter'].sudo().set_param(
+            'web.base.url', BASE_URL)
+
+        self.test_user = self.env.ref('base.user_root')
+
+    @patch(MODEL_PATH + '.request')
+    def test_create_device(self, request_mock):
+        request_mock.session.u2f_last_registration_challenge = REQUEST_DATA
+
+        device = self.env['u2f.device'].create({
+            'name': 'Test Authenticator',
+            'json': json.dumps(RESPONSE_DATA),
+            'user_id': self.test_user.id,
+            'default': True,
+        })
+
+        self.assertTrue(device)
+        data = json.loads(device.json)
+
+        for key, value in DEVICE_DATA.items():
+            self.assertEqual(data[key], value, key)
+
+    @patch(MODEL_PATH + '.u2f')
+    @patch(MODEL_PATH + '.request')
+    def test_make_default(self, request_mock, u2f_mock):
+        m = MagicMock(json=TEST_VALUE)
+        u2f_mock.complete_registration.return_value = m, True
+        request_mock.session.u2f_last_registration_challenge = TEST_VALUE
+
+        data = json.dumps(RESPONSE_DATA)
+        device_a = self.env['u2f.device'].create({
+            'name': 'Test Authenticator',
+            'json': data,
+            'user_id': self.test_user.id,
+            'default': True,
+        })
+
+        u2f_mock.complete_registration.assert_called_once_with(
+            TEST_VALUE, data, [BASE_URL])
+
+        device_b = self.env['u2f.device'].create({
+            'name': 'Test Authenticator',
+            'json': json.dumps(RESPONSE_DATA),
+            'user_id': self.test_user.id,
+            'default': True,
+        })
+
+        self.assertFalse(device_a.default)
+        self.assertTrue(device_b.default)
+
+        device_a.action_make_default()
+        self.assertTrue(device_a.default)
+        self.assertFalse(device_b.default)

--- a/auth_u2f/tests/test_http.py
+++ b/auth_u2f/tests/test_http.py
@@ -1,0 +1,108 @@
+# Copyright (C) 2019 initOS GmbH
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+import json
+import logging
+from unittest.mock import patch
+
+from odoo.exceptions import AccessDenied
+from odoo.tests.common import TransactionCase
+from ..models.http import U2FAuthenticationError
+from .test_main import BASE_URL, REQUEST_DATA, RESPONSE_DATA
+
+
+ADDON_PATH = 'odoo.addons.auth_u2f'
+AUTH_PATH = 'odoo.addons.base.ir.ir_http.IrHttp._authenticate'
+DEVICE_PATH = ADDON_PATH + '.models.u2f_device'
+HTTP_PATH = ADDON_PATH + '.models.http'
+USER_PATH = ADDON_PATH + '.models.res_users'
+
+
+_logger = logging.getLogger(__name__)
+
+
+@patch(HTTP_PATH + '.request')
+class TestUsers(TransactionCase):
+
+    @patch(DEVICE_PATH + '.request')
+    def setUp(self, request_mock):
+        super(TestUsers, self).setUp()
+
+        self.env['ir.config_parameter'].sudo().set_param(
+            'web.base.url', BASE_URL)
+
+        self.test_user = self.env.ref('base.user_root')
+
+        request_mock.session.u2f_last_registration_challenge = REQUEST_DATA
+
+        self.device = self.env['u2f.device'].create({
+            'name': 'Test Authenticator',
+            'json': json.dumps(RESPONSE_DATA),
+            'user_id': self.test_user.id,
+            'default': True,
+        })
+
+    def _authenticate(self, auth_method):
+        return self.env['ir.http']._authenticate(auth_method)
+
+    @patch(AUTH_PATH)
+    def test_authenticate(self, super_mock, request_mock):
+        request_mock.session.uid = self.test_user.id
+        super_mock.return_value = 'U2F Test Ok'
+
+        self.assertEqual(self._authenticate('user'), super_mock.return_value)
+
+    @patch(AUTH_PATH)
+    def test_authenticate_without_2nd_factor(self, super_mock, request_mock):
+        request_mock.session.uid = self.test_user.id
+        super_mock.return_value = 'U2F Test Ok'
+
+        self.assertEqual(self._authenticate('none'), super_mock.return_value)
+
+    @patch(AUTH_PATH)
+    def test_authenticate_1st_factor_fail(self, super_mock, request_mock):
+        request_mock.session.uid = self.test_user.id
+        super_mock.side_effect = AccessDenied()
+
+        try:
+            self.env['ir.http']._authenticate()
+        except AccessDenied:
+            pass
+
+    @patch(AUTH_PATH)
+    @patch(USER_PATH + '.ResUsers.u2f_check_credentials')
+    @patch(HTTP_PATH + '.api.Environment')
+    def test_auth_2nd_fail(self, env_mock, check_mock, super_mock, req_mock):
+        env_mock.return_value = self.env
+        req_mock.session.uid = self.test_user.id
+        check_mock.side_effect = U2FAuthenticationError()
+
+        try:
+            self._authenticate('user')
+        except U2FAuthenticationError:
+            pass
+
+    @patch(AUTH_PATH)
+    @patch(HTTP_PATH + '.api.Environment')
+    def test_auth_no_device(self, env_mock, super_mock, request_mock):
+        env_mock.return_value = self.env
+        super_mock.return_value = 'U2F Test Ok'
+        request_mock.session.uid = self.test_user.id
+
+        self.device.unlink()
+
+        self.assertEqual(self._authenticate('user'), super_mock.return_value)

--- a/auth_u2f/tests/test_main.py
+++ b/auth_u2f/tests/test_main.py
@@ -1,0 +1,169 @@
+# Copyright (C) 2019 initOS GmbH
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+import json
+import logging
+import unittest.mock as mock
+
+from odoo.exceptions import AccessDenied
+from odoo.addons.auth_u2f.controllers.main import AuthU2FController, U2FLogin
+from odoo.addons.auth_u2f.models.http import U2FAuthenticationError
+from odoo.tests.common import TransactionCase
+
+
+REQUEST_DATA = {
+    'appId': 'http://localhost',
+    'registeredKeys': [],
+    'registerRequests': [{
+        'challenge': u'ro-1pJjGqG8IjsaavEON7enhuBRLVsGpA6uMIc6Vle4',
+        'version': 'U2F_V2'
+    }],
+}
+
+RESPONSE_DATA = {
+    'version': 'U2F_V2',
+    'registrationData':
+        u'BQRFVDpgpafxroN_Rt7FcRQN8LbBLujnd9iayp-UKkT1tvIJhFefSb9GQHkOFd2yj49'
+        u'IsHA3JHWTutW_GwD49NwrQI_ccuvlvKzKdVkuxLCH2FjWPnHVx2nKtt7EEt4aibTwLi'
+        u'hepxbkxTzIl-VWmcXrwiZlvkNyjb0gHyXbSJ7JdSUwggGHMIIBLqADAgECAgkAmb7os'
+        u'Qyi7BwwCQYHKoZIzj0EATAhMR8wHQYDVQQDDBZZdWJpY28gVTJGIFNvZnQgRGV2aWNl'
+        u'MB4XDTEzMDcxNzE0MjEwM1oXDTE2MDcxNjE0MjEwM1owITEfMB0GA1UEAwwWWXViaWN'
+        u'vIFUyRiBTb2Z0IERldmljZTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABDvhl91zfp'
+        u'g9n7DeCedcQ8gGXUnemiXoi-JEAxz-EIhkVsMPAyzhtJZ4V3CqMZ-MOUgICt2aMxacM'
+        u'X9cIa8dgS2jUDBOMB0GA1UdDgQWBBQNqL-TV04iaO6mS5tjGE6ShfexnjAfBgNVHSME'
+        u'GDAWgBQNqL-TV04iaO6mS5tjGE6ShfexnjAMBgNVHRMEBTADAQH_MAkGByqGSM49BAE'
+        u'DSAAwRQIgXJWZdbvOWdhVaG7IJtn44o21Kmi8EHsDk4cAfnZ0r38CIQD6ZPi3Pl4lXx'
+        u'bY7BXFyrpkiOvCpdyNdLLYbSTbvIBQOTBFAiA5MoyJbjgdLkeWmPb1k9YIDNfc0Hhzl'
+        u'itPh81C9NFX4AIhAMMHxu0gPhO8GHZS72mG8Txh98ka3lf9yFbTyyyIoePR',
+    'clientData': u'eyJvcmlnaW4iOiAiaHR0cDovL2xvY2FsaG9zdCIsICJjaGFsbGVuZ2UiO'
+        u'iAicm8tMXBKakdxRzhJanNhYXZFT043ZW5odUJSTFZzR3BBNnVNSWM2VmxlNCIsICJ0'
+        u'eXAiOiAibmF2aWdhdG9yLmlkLmZpbmlzaEVucm9sbG1lbnQifQ',
+}
+
+
+DEVICE_DATA = {
+    'version': u'U2F_V2',
+    'transports': None,
+    'appId': u'http://localhost',
+    'publicKey':
+        u'BEVUOmClp_Gug39G3sVxFA3wtsEu6Od32JrKn5QqRPW28gmEV59Jv0ZAeQ4V3bKPj0i'
+        u'wcDckdZO61b8bAPj03Cs', 'keyHandle': u'j9xy6-W8rMp1WS7EsIfYWNY-cdXHa'
+        u'cq23sQS3hqJtPAuKF6nFuTFPMiX5VaZxevCJmW-Q3KNvSAfJdtInsl1JQ',
+}
+
+BASE_URL = 'http://localhost'
+TEST_VALUE = b'U2F Test Token'
+
+ADDON_PATH = 'odoo.addons.auth_u2f'
+CONTROLLER_PATH = ADDON_PATH + '.controllers.main'
+DEVICE_PATH = ADDON_PATH + '.models.u2f_device'
+
+_logger = logging.getLogger(__name__)
+
+
+@mock.patch(CONTROLLER_PATH + '.request')
+class TestAuthU2f(TransactionCase):
+
+    @mock.patch(DEVICE_PATH + '.request')
+    def setUp(self, request_mock):
+        super(TestAuthU2f, self).setUp()
+
+        self.env['ir.config_parameter'].sudo().set_param(
+            'web.base.url', BASE_URL)
+
+        self.controller = AuthU2FController()
+        self.login = U2FLogin()
+
+        self.test_user = self.env.ref('base.user_root')
+
+        request_mock.session.u2f_last_registration_challenge = REQUEST_DATA
+
+        self.device = self.env['u2f.device'].create({
+            'name': 'Test Authenticator',
+            'json': json.dumps(RESPONSE_DATA),
+            'user_id': self.test_user.id,
+            'default': True,
+        })
+
+        # Needed when tests are run with no prior requests (e.g. on a new DB)
+        patcher = mock.patch('odoo.http.request')
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_login(self, request_mock):
+        request_mock.env = self.env
+        request_mock.session.uid = self.test_user.id
+        request_mock.session.u2f_last_registration_challenge = REQUEST_DATA
+        request_mock.render.return_value = b"OK"
+
+        response = self.controller.u2f_login()
+        request_mock.render.assert_called_once_with('auth_u2f.login', mock.ANY)
+        self.assertEqual(response.get_data(), request_mock.render.return_value)
+
+    def test_login_fail_no_device(self, request_mock):
+        self.device.unlink()
+        request_mock.env = self.env
+        request_mock.session.uid = self.test_user.id
+
+        try:
+            self.controller.u2f_login()
+        except AccessDenied:
+            pass
+
+    @mock.patch(CONTROLLER_PATH + '.http')
+    def test_login_post(self, http_mock, request_mock):
+        request_mock.env = self.env
+        request_mock.session.uid = self.test_user.id
+        request_mock.render.side_effect = lambda x: x
+        request_mock.httprequest.method = 'POST'
+
+        return_value = TEST_VALUE
+        http_mock.redirect_with_hash.return_value = return_value
+
+        response = self.controller.u2f_login(TEST_VALUE, '/u2f/ok')
+
+        http_mock.redirect_with_hash.assert_called_once_with('/u2f/ok')
+        self.assertEqual(request_mock.session.u2f_token_response, TEST_VALUE)
+        self.assertEqual(response.get_data(), return_value)
+
+    @mock.patch(CONTROLLER_PATH + '.Home.web_client')
+    def test_web_client(self, super_mock, request_mock):
+        auth_mock = mock.MagicMock()
+        request_mock.env = {'ir.http': auth_mock}
+        request_mock.session.uid = self.test_user.id
+
+        super_mock.return_value = TEST_VALUE
+
+        response = self.login.web_client()
+        self.assertTrue(super_mock.call_count)
+        self.assertTrue(auth_mock._authenticate.call_count)
+        self.assertEqual(response.get_data(), super_mock.return_value)
+
+    @mock.patch(CONTROLLER_PATH + '.werkzeug.utils.redirect')
+    @mock.patch(CONTROLLER_PATH + '.Home.web_client')
+    def test_web_client_fail(self, super_mock, redirect_mock, request_mock):
+        auth_mock = mock.MagicMock()
+        auth_mock.side_effect = U2FAuthenticationError()
+        request_mock.env = {'ir.http': mock.MagicMock(_authenticate=auth_mock)}
+        redirect_mock.return_value = TEST_VALUE
+
+        response = self.login.web_client()
+
+        self.assertTrue(auth_mock.call_count)
+        self.assertTrue(super_mock.call_count)
+        redirect_mock.assert_called_once_with('/web/u2f/login', 303)
+        self.assertEqual(response.get_data(), TEST_VALUE)

--- a/auth_u2f/tests/test_users.py
+++ b/auth_u2f/tests/test_users.py
@@ -1,0 +1,135 @@
+# Copyright (C) 2019 initOS GmbH
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+import json
+import logging
+from unittest.mock import MagicMock, patch
+
+from odoo.tests.common import TransactionCase
+from .test_main import BASE_URL, REQUEST_DATA, RESPONSE_DATA, TEST_VALUE
+from odoo.addons.auth_u2f.models.http import U2FAuthenticationError
+
+
+_logger = logging.getLogger(__name__)
+
+
+MODELS_PATH = 'odoo.addons.auth_u2f.models'
+
+
+class TestUsers(TransactionCase):
+
+    @patch(MODELS_PATH + '.u2f_device.request')
+    def setUp(self, request_mock):
+        super(TestUsers, self).setUp()
+
+        self.env['ir.config_parameter'].sudo().set_param(
+            'web.base.url', BASE_URL)
+
+        self.test_user = self.env.ref('base.user_root')
+
+        request_mock.session.u2f_last_registration_challenge = REQUEST_DATA
+
+        self.device = self.env['u2f.device'].create({
+            'name': 'Test Authenticator',
+            'json': json.dumps(RESPONSE_DATA),
+            'user_id': self.test_user.id,
+            'default': True,
+        })
+
+    @patch(MODELS_PATH + '.u2f_device.u2f')
+    @patch(MODELS_PATH + '.u2f_device.request')
+    def test_get_device(self, request_mock, u2f_mock):
+        m = MagicMock(json=TEST_VALUE)
+        u2f_mock.complete_registration.return_value = m, True
+
+        device_b = self.env['u2f.device'].create({
+            'name': 'Test Authenticator',
+            'json': "Test",
+            'user_id': self.test_user.id,
+            'default': True,
+        })
+
+        devices = self.test_user._u2f_get_device()
+        self.assertIn(device_b, devices)
+        self.assertNotIn(self.device, devices)
+
+    def test_get_device_no_default_device(self):
+        self.device.default = False
+        self.assertFalse(self.test_user._u2f_get_device())
+
+    def test_get_device_no_device(self):
+        self.device.unlink()
+        self.assertFalse(self.test_user._u2f_get_device())
+
+    @patch(MODELS_PATH + '.res_users.u2f')
+    @patch(MODELS_PATH + '.res_users.request')
+    def test_get_registration_challenge(self, request_mock, u2f_mock):
+        m = MagicMock(json=TEST_VALUE)
+        u2f_mock.begin_registration.return_value = m
+
+        self.assertEqual(self.test_user.u2f_get_registration_challenge(), m)
+        self.assertEqual(
+            request_mock.session.u2f_last_registration_challenge, TEST_VALUE)
+
+    @patch(MODELS_PATH + '.res_users.u2f')
+    def test_get_login_challenge(self, u2f_mock):
+        u2f_mock.begin_authentication.return_value = TEST_VALUE
+        self.assertEqual(self.test_user._u2f_get_login_challenge(), TEST_VALUE)
+
+        u2f_mock.begin_authentication.assert_called_once_with(
+            BASE_URL, [self.device.json])
+
+        self.device.default = False
+        self.assertFalse(self.test_user._u2f_get_login_challenge())
+
+    @patch(MODELS_PATH + '.res_users.u2f')
+    def test_check_credentials_success(self, u2f_mock):
+        u2f_mock.complete_authentication.return_value = True, True, True
+        self.assertTrue(self.test_user.u2f_check_credentials(True, True))
+
+    @patch(MODELS_PATH + '.res_users.u2f')
+    def test_check_credentials_no_device(self, u2f_mock):
+        self.device.default = False
+        u2f_mock.complete_authentication.return_value = True, True, True
+        self.assertTrue(self.test_user.u2f_check_credentials(True, True))
+
+    @patch(MODELS_PATH + '.res_users.u2f')
+    def test_check_credentials_missing_response(self, u2f_mock):
+        u2f_mock.complete_authentication.return_value = True, True, True
+        try:
+            self.test_user.u2f_check_credentials(True, False)
+            self.fail()
+        except U2FAuthenticationError:
+            pass
+
+    @patch(MODELS_PATH + '.res_users.u2f')
+    def test_check_credentials_missing_challenge(self, u2f_mock):
+        u2f_mock.complete_authentication.return_value = True, True, True
+        try:
+            self.test_user.u2f_check_credentials(False, True)
+            self.fail()
+        except U2FAuthenticationError:
+            pass
+
+    @patch(MODELS_PATH + '.res_users.u2f')
+    def test_check_credentials_fail(self, u2f_mock):
+        u2f_mock.complete_authentication.return_value = False
+        try:
+            self.test_user.u2f_check_credentials(False, True)
+            self.fail()
+        except U2FAuthenticationError:
+            pass

--- a/auth_u2f/views/res_users.xml
+++ b/auth_u2f/views/res_users.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_users_form_inherit_auth_u2f" model="ir.ui.view">
+            <field name="name">res.users.form.inherit</field>
+            <field name="model">res.users</field>
+            <field name="type">form</field>
+            <field name="inherit_id" ref="base.view_users_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//page[@name='access_rights']" position="after">
+                    <page string="U2F">
+                        <group>
+                            <field name="u2f_device_ids"/>
+                        </group>
+                    </page>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/auth_u2f/views/u2f_device.xml
+++ b/auth_u2f/views/u2f_device.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="u2f_device_tree" model="ir.ui.view">
+            <field name="name">u2f.device.tree</field>
+            <field name="model">u2f.device</field>
+            <field name="arch" type="xml">
+                <tree>
+                    <field name="name"/>
+                    <field name="default"/>
+                </tree>
+            </field>
+        </record>
+        <record id="u2f_device_form" model="ir.ui.view">
+            <field name="name">u2f.device.form</field>
+            <field name="model">u2f.device</field>
+            <field name="arch" type="xml">
+                <form>
+                    <header>
+                        <button name="action_make_default" string="Make default"
+                                type="object" attrs="{'invisible': [('default', '=', True)]}"
+                                class="oe_highlight"/>
+                    </header>
+                    <group>
+                        <field name="name"/>
+                        <field name="default"/>
+                        <field name="json" widget="u2f_scan"/>
+                        <field name="user_id" invisible="1"/>
+                    </group>
+                </form>
+            </field>
+        </record>
+
+        <record model="ir.actions.act_window" id="action_open_u2f_device_tree">
+            <field name="name">U2F devices</field>
+            <field name="res_model">u2f.device</field>
+            <field name="view_mode">tree,form</field>
+            <field name="target">current</field>
+            <field name="context">{'default_user_id': uid}</field>
+            <field name="domain">[('user_id', '=', uid)]</field>
+        </record>
+
+        <record id="view_users_form_simple_modif_inherit_auth_u2f" model="ir.ui.view">
+            <field name="name">res.users.preferences.form</field>
+            <field name="model">res.users</field>
+            <field name="inherit_id" ref="base.view_users_form_simple_modif"/>
+            <field name="arch" type="xml">
+                <button name="preference_change_password" position="after">
+                    <button type="action" name="%(action_open_u2f_device_tree)d"
+                            string="Manage 2-step verification" class="oe_link"/>
+                </button>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/auth_u2f/views/u2f_templates.xml
+++ b/auth_u2f/views/u2f_templates.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <template id="assets_frontend" name="U2F Assets" inherit_id="web.assets_frontend">
+            <xpath expr="." position="inside">
+                <script type="text/javascript" src="/auth_u2f/static/lib/u2f-api.js"></script>
+                <script type="text/javascript" src="/auth_u2f/static/src/js/auth_u2f_frontend.js"></script>
+            </xpath>
+        </template>
+
+        <template id="assets_backend" name="U2F Assets" inherit_id="web.assets_backend">
+            <xpath expr="." position="inside">
+                <script type="text/javascript" src="/auth_u2f/static/lib/u2f-api.js"></script>
+                <script type="text/javascript" src="/auth_u2f/static/src/js/auth_u2f.js"></script>
+            </xpath>
+        </template>
+
+        <template id="login" name="Register U2F page">
+            <t t-call="web.layout">
+                <t t-set="head">
+                    <t t-call-assets="web.assets_common" t-js="false"/>
+                    <t t-call-assets="web.assets_frontend" t-js="false"/>
+                    <t t-call-assets="web.assets_common" t-css="false"/>
+                    <t t-call-assets="web.assets_frontend" t-css="false"/>
+                </t>
+                <t t-set="body_classname" t-value="'container'"/>
+                <div class="row">
+                    <div class="col-md-6 col-md-offset-3">
+                        <div class="text-center">
+                            <h3>Use your security key to sign in</h3>
+                            <p>Insert your security key into your computer's USB port. If it has a button, tap it.</p>
+                            <i class="fa fa-spinner fa-spin" style="font-size: 32px;"></i>
+                            <p id="error_message" style="color: red;"/>
+                            <form method="POST" action="/web/u2f/login" id="u2f_login_form" onsubmit="return false;">
+                                <input type="hidden" name="redirect" t-att-value="redirect"/>
+                                <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                                <input type="hidden" id="u2f_challenge" name="u2f_challenge" t-att-value="login_data"/>
+                                <input type="hidden" id="u2f_token_response" name="u2f_token_response"/>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </t>
+        </template>
+    </data>
+</odoo>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ email_validator
 lasso
 # auth_totp
 pyotp
+# auth_u2f
+python-u2flib-server


### PR DESCRIPTION
This module allows odoo to use FIDO U2F hardware tokens as a 2nd factor authentication.

It's tested with the U2F versions of Yubikey and Nitrokey and recent versions of Firefox and Chrome.