### PR TITLE
auth_keycloak: improve scripts

### DIFF
--- a/auth_keycloak/examples/cli.py
+++ b/auth_keycloak/examples/cli.py
@@ -2,23 +2,26 @@
 # pylint: disable=W7935, W7936, W0403
 
 import click
-from urlparse import urljoin
+try:
+    from urlparse import urljoin
+except ImportError:
+    from urllib.parse import urljoin
 import os
 import sys
 import json
 from get_token import get_token
 from common import (
-    DATA_FILE, VALIDATE_PATH,
+    TOKEN_DATA_FILE, VALIDATE_PATH,
     USERINFO_PATH, USERS_PATH,
     do_request
 )
 
 
 def _read_data():
-    if not os.path.isfile(DATA_FILE):
+    if not os.path.isfile(TOKEN_DATA_FILE):
         click.echo('You must run `get_token` before.')
         sys.exit(0)
-    with open(DATA_FILE, 'r') as ff:
+    with open(TOKEN_DATA_FILE, 'r') as ff:
         return json.loads(ff.read())
 
 

--- a/auth_keycloak/examples/common.py
+++ b/auth_keycloak/examples/common.py
@@ -18,7 +18,8 @@ USERINFO_PATH = BASE_PATH + '/userinfo'
 # Watch out w/ official docs, they are wrong here
 # https://issues.jboss.org/browse/KEYCLOAK-8615
 USERS_PATH = '/auth/admin/realms/{realm}/users'
-DATA_FILE = '/tmp/keycloak.json'
+TOKEN_DATA_FILE = '/tmp/keycloak.token.json'
+DEFAULTS_DATA_FILE = '/tmp/keycloak.defaults.json'
 
 
 def do_request(method, url, **kw):

--- a/auth_keycloak/examples/get_token.py
+++ b/auth_keycloak/examples/get_token.py
@@ -2,49 +2,80 @@
 # pylint: disable=W7935, W7936, W0403
 
 import click
-from urlparse import urljoin
+import os
+try:
+    from urlparse import urljoin
+except ImportError:
+    from urllib.parse import urljoin
+
 import json
 
 from common import (
     UID, PWD,
     CLIENT_ID, CLIENT_SECRET,
-    DATA_FILE, DOMAIN, REALM,
+    TOKEN_DATA_FILE, DEFAULTS_DATA_FILE,
+    DOMAIN, REALM,
     GET_TOKEN_PATH,
     do_request
 )
 
+default_conf = {
+    'domain': DOMAIN,
+    'realm': REALM,
+    'username': UID,
+    'password': PWD,
+    'client_id': CLIENT_ID,
+    'client_secret': CLIENT_SECRET,
+}
+
+if os.path.isfile(DEFAULTS_DATA_FILE):
+    click.echo('Loading defaults from %s' % DEFAULTS_DATA_FILE)
+    with open(DEFAULTS_DATA_FILE, 'r') as ff:
+        default_conf = json.loads(ff.read())
+
 
 @click.command()
-@click.option('--domain', default=DOMAIN)
-@click.option('--realm', default=REALM)
+@click.option(
+    '--domain',
+    default=default_conf['domain'],
+    prompt='domain',
+)
+@click.option(
+    '--realm',
+    default=default_conf['realm'],
+    prompt='realm',
+)
 @click.option(
     '--username',
     prompt='Username',
     help='Username to authenticate.',
-    default=UID)
+    default=default_conf['username'])
 @click.option(
     '--password',
     prompt='Password',
-    default=PWD)
+    default=default_conf['password'])
 @click.option(
     '--client_id',
     prompt='Client ID',
     help='Keycloak client ID.',
-    default=CLIENT_ID)
+    default=default_conf['client_id'])
 @click.option(
     '--client_secret',
     prompt='Client secret',
     help='Keycloak client secret.',
-    default=CLIENT_SECRET)
+    default=default_conf['client_secret'])
 def get_token(**kw):
     """Retrieve auth token."""
     data = kw.copy()
     data['grant_type'] = 'password'
     token = _get_token(data)
     data['token'] = token
-    with open(DATA_FILE, 'w') as ff:
+    with open(TOKEN_DATA_FILE, 'w') as ff:
         ff.write(json.dumps(data))
-        click.echo('Saved to %s' % DATA_FILE)
+        click.echo('Token saved to %s' % TOKEN_DATA_FILE)
+    with open(DEFAULTS_DATA_FILE, 'w') as ff:
+        ff.write(json.dumps(data))
+        click.echo('Defaults saved to %s' % DEFAULTS_DATA_FILE)
     return token
 
 


### PR DESCRIPTION
Store default values on each run so to not type them over and over
for calls to the same service.