### PR TITLE
[FIX] Monkeypatch TestCursor in auth_brute_force's tests

### DIFF
--- a/auth_brute_force/tests/test_brute_force.py
+++ b/auth_brute_force/tests/test_brute_force.py
@@ -44,6 +44,65 @@ def skip_unless_addons_installed(*addons):
     return _wrapper
 
 
+def patch_cursor(func):
+    """ Decorator that patches the current TestCursor for nested savepoint
+    support. Obsolete in 12.0 and up. """
+    def acquire(cursor):
+        cursor._depth += 1
+        cursor._lock.acquire()
+        cursor.execute("SAVEPOINT test_cursor%d" % cursor._depth)
+
+    def release(cursor):
+        cursor.execute("RELEASE SAVEPOINT test_cursor%d" % cursor._depth)
+        cursor._depth -= 1
+        cursor._lock.release()
+
+    def close(cursor):
+        cursor.release()
+
+    def commit(cursor):
+        cursor.execute("RELEASE SAVEPOINT test_cursor%d" % cursor._depth)
+        cursor.execute("SAVEPOINT test_cursor%d" % cursor._depth)
+
+    def rollback(cursor):
+        cursor.execute(
+            "ROLLBACK TO SAVEPOINT test_cursor%d" % cursor._depth)
+        cursor.execute("SAVEPOINT test_cursor%d" % cursor._depth)
+
+    def wrap(func, *args):
+
+        def wrapped_function(self, *args):
+            with self.cursor() as cursor:
+                cursor.execute("SAVEPOINT test_cursor0")
+                cursor._depth = 1
+                cursor.execute("SAVEPOINT test_cursor%d" % cursor._depth)
+
+                cursor.__acquire = cursor.acquire
+                cursor.__release = cursor.release
+                cursor.__commit = cursor.commit
+                cursor.__rollback = cursor.rollback
+                cursor.__close = cursor.close
+                cursor.acquire = lambda: acquire(cursor)
+                cursor.release = lambda: release(cursor)
+                cursor.commit = lambda: commit(cursor)
+                cursor.rollback = lambda: rollback(cursor)
+                cursor.close = lambda: close(cursor)
+
+            try:
+                func(self, *args)
+            finally:
+                with self.cursor() as cursor:
+                    cursor.acquire = cursor.__acquire
+                    cursor.release = cursor.__release
+                    cursor.commit = cursor.__commit
+                    cursor.rollback = cursor.__rollback
+                    cursor.close = cursor.__close
+
+        return wrapped_function
+
+    return wrap
+
+
 @at_install(False)
 @post_install(True)
 # Skip CSRF validation on tests
@@ -94,6 +153,7 @@ class BruteForceCase(HttpCase):
 
     @skip_unless_addons_installed("web")
     @mute_logger(*GARBAGE_LOGGERS)
+    @patch_cursor
     def test_web_login_existing(self, *args):
         """Remote is banned with real user on web login form."""
         data1 = {
@@ -167,6 +227,7 @@ class BruteForceCase(HttpCase):
 
     @skip_unless_addons_installed("web")
     @mute_logger(*GARBAGE_LOGGERS)
+    @patch_cursor
     def test_web_login_existing_unbanned(self, *args):
         """Remote is banned with real user on web login form."""
         data1 = {
@@ -238,6 +299,7 @@ class BruteForceCase(HttpCase):
 
     @skip_unless_addons_installed("web")
     @mute_logger(*GARBAGE_LOGGERS)
+    @patch_cursor
     def test_web_login_unexisting(self, *args):
         """Remote is banned with fake user on web login form."""
         data1 = {
@@ -294,6 +356,7 @@ class BruteForceCase(HttpCase):
             self.assertEqual(len(banned), 0)
 
     @mute_logger(*GARBAGE_LOGGERS)
+    @patch_cursor
     def test_xmlrpc_login_existing(self, *args):
         """Remote is banned with real user on XML-RPC login."""
         data1 = {
@@ -353,6 +416,7 @@ class BruteForceCase(HttpCase):
             self.env.cr.dbname, data1["login"], data1["password"], {}))
 
     @mute_logger(*GARBAGE_LOGGERS)
+    @patch_cursor
     def test_xmlrpc_login_existing_unbanned(self, *args):
         """Remote is banned with real user on XML-RPC login."""
         data1 = {
@@ -433,6 +497,7 @@ class BruteForceCase(HttpCase):
             self.env.cr.dbname, data1["login"], data1["password"], {}))
 
     @mute_logger(*GARBAGE_LOGGERS)
+    @patch_cursor
     def test_xmlrpc_login_unexisting(self, *args):
         """Remote is banned with fake user on XML-RPC login."""
         data1 = {


### PR DESCRIPTION
By implementing nestable savepoints in the TestCursor (courtesy of
Holger Brunn), the failed login attempts are preserved during the test.

See https://github.com/odoo/odoo/pull/20033. A similar mechanism has been adopted in Odoo 12.0 so there is no need to port this further.

Port of https://github.com/OCA/server-tools/pull/1526