### PR TITLE
[FIX] 12.0 `password_security` module

### DIFF
--- a/password_security/__manifest__.py
+++ b/password_security/__manifest__.py
@@ -14,6 +14,7 @@
     'category': 'Base',
     'depends': [
         'auth_signup',
+        'auth_password_policy',
         'auth_password_policy_signup',
     ],
     "website": "https://github.com/OCA/server-auth",
@@ -21,6 +22,7 @@
     "data": [
         'views/password_security.xml',
         'views/res_config_settings_views.xml',
+        'views/signup_templates.xml',
         'security/ir.model.access.csv',
         'security/res_users_pass_history.xml',
     ],

--- a/password_security/views/password_security.xml
+++ b/password_security/views/password_security.xml
@@ -4,9 +4,17 @@
     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 -->
 <odoo>
+
     <template id="assets_common" inherit_id="web.assets_common" name="Password Security Common Assets">
-        <xpath expr="." position="inside">
-            <script type="text/javascript" src="/password_security/static/src/js/password_gauge.js"></script>
+        <xpath expr="//script[@src='/auth_password_policy/static/src/js/password_gauge.js']" position="after">
+             <script type="text/javascript" src="/password_security/static/src/js/password_gauge.js"></script>
+         </xpath>
+     </template>
+
+    <template id="assets_frontend" inherit_id="web.assets_frontend" name="Password Security Frontend Assets">
+         <xpath expr="." position="inside">
+            <script type="text/javascript" src="/password_security/static/src/js/signup_policy.js"></script>
         </xpath>
     </template>
+
 </odoo>

--- a/password_security/views/signup_templates.xml
+++ b/password_security/views/signup_templates.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <template id="fields" inherit_id="auth_password_policy_signup.fields" name="Password policy data for auth_signup/password_security">
+        <xpath expr="//input[@name='password']" position="attributes">
+            <!-- Remove original meter from `auth_password_policy_signup` -->
+            <attribute name="t-att-minlength"/>
+            <!-- Add new attributes required by `password_security` -->
+            <attribute name="t-att-password_length">password_length</attribute>
+            <attribute name="t-att-password_lower">password_lower</attribute>
+            <attribute name="t-att-password_upper">password_upper</attribute>
+            <attribute name="t-att-password_numeric">password_numeric</attribute>
+            <attribute name="t-att-password_special">password_special</attribute>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
frontend meter/badgets/popup when using `password_security` module on signup/reset-password fronted pages.

Problems was solved by this PR:

1) Meter on frontend pages did works incorrectly.
2) Original meter from `auth_password_policy_signup` conflicts with meter from `password_security`. I did disable meter from `auth_password_policy_signup`.
3) Recommendations didn't worked correctly.

It's regression after migration to 12.0 and adding new features.