### PR TITLE
[FIX] change auth.api.key type from TransientModel to Model

### DIFF
--- a/auth_api_key/__manifest__.py
+++ b/auth_api_key/__manifest__.py
@@ -12,6 +12,6 @@
     "website": "https://acsone.eu/",
     "development_status": "Beta",
     "depends": ["server_environment"],
-    "data": [],
+    "data": ['security/ir.model.access.csv',],
     "demo": [],
 }

--- a/auth_api_key/models/auth_api_key.py
+++ b/auth_api_key/models/auth_api_key.py
@@ -10,7 +10,7 @@ from odoo.tools import consteq
 from odoo.exceptions import ValidationError, AccessError
 
 
-class AuthApiKey(models.TransientModel):
+class AuthApiKey(models.Model):
     _name = "auth.api.key"
 
     @api.model

--- a/auth_api_key/security/ir.model.access.csv
+++ b/auth_api_key/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_auth_api_key,access_auth_api_key,model_auth_api_key,,1,0,0,0
+access_auth_api_key_admin,access_auth_api_key_admin,model_auth_api_key,base.group_system,1,1,1,1


### PR DESCRIPTION
Change auth.api.key type from TransientModel to Model to can reference it in other models. 
ex : 
https://github.com/akretion/ak-odoo-incubator/blob/10.0/project_api/models/partner.py#L13

Bug AssertionError: Many2One relationships from non-transient Model to TransientModel are forbidden