### PR TITLE
[ADD] auth_api_key: add an option to allow to use inactive users

### DIFF
--- a/auth_api_key/models/auth_api_key.py
+++ b/auth_api_key/models/auth_api_key.py
@@ -25,9 +25,15 @@ class AuthApiKey(models.TransientModel):
             ):
                 if not consteq(api_key, serv_config.get(section, "key")):
                     continue
+                user_model = self.env["res.users"]
+                if serv_config.has_option(section, "allow_inactive_user"):
+                    allow_inactive_user = serv_config.getboolean(
+                        section, "allow_inactive_user")
+                    if allow_inactive_user:
+                        user_model = user_model.with_context(active_test=False)
 
                 login_name = serv_config.get(section, "user")
-                uid = self.env["res.users"].search(
+                uid = user_model.search(
                     [("login", "=", login_name)]).id
 
                 if not uid:

--- a/auth_api_key/readme/USAGE.rst
+++ b/auth_api_key/readme/USAGE.rst
@@ -8,3 +8,9 @@ as value for the 'auth' parameter of your route definition into your controller.
         @route('/my_service', auth='api_key', ...)
         def my_service(self, *args, **kwargs):
             pass
+
+It is possible to associate an inactive user to the key by adding an optional attribute to your configuration parameter:
+  * allow_inactive_user: True or False
+
+Be careful if you use this feature as the problem with inactive users is that they will be removed from the group that they are in as soon as you edit the user list on an ir.group.
+The m2m widget for users on the group will not include them - as they are inactive, so if you changes the list, it will remove it.

--- a/auth_api_key/tests/test_auth_api_key.py
+++ b/auth_api_key/tests/test_auth_api_key.py
@@ -17,6 +17,17 @@ class TestAuthApiKey(TransactionCase):
         serv_config.add_section("api_key_bad")
         serv_config.set("api_key_bad", "user", "not_demo")
         serv_config.set("api_key_bad", "key", "api_wrong_key")
+        serv_config.add_section("api_key_inactive_ok")
+        serv_config.set("api_key_inactive_ok", "user", "demo")
+        serv_config.set("api_key_inactive_ok", "key", "api_inactive_ok_key")
+        serv_config.set("api_key_inactive_ok", "allow_inactive_user", "True")
+        serv_config.add_section("api_key_inactive_nok")
+        serv_config.set("api_key_inactive_nok", "user", "demo")
+        serv_config.set("api_key_inactive_nok", "key", "api_inactive_nok_key")
+        serv_config.set("api_key_inactive_nok", "allow_inactive_user", "False")
+        serv_config.add_section("api_key_inactive_off")
+        serv_config.set("api_key_inactive_off", "user", "demo")
+        serv_config.set("api_key_inactive_off", "key", "api_inactive_off_key")
 
     def test_lookup(self):
         demo_user = self.env.ref("base.user_demo")
@@ -36,3 +47,26 @@ class TestAuthApiKey(TransactionCase):
         with self.assertRaises(AccessError), self.env.cr.savepoint():
             self.env["auth.api.key"].sudo(user=demo_user).\
                 _retrieve_uid_from_api_key("api_wrong_key")
+
+    def test_user_inactive_allowed(self):
+        demo_user = self.env.ref("base.user_demo")
+        demo_user.write({'active': False})
+        self.assertEqual(
+            self.env["auth.api.key"]._retrieve_uid_from_api_key(
+                "api_inactive_ok_key"),
+            demo_user.id,
+        )
+
+    def test_user_inactive_not_allowed(self):
+        demo_user = self.env.ref("base.user_demo")
+        demo_user.write({'active': False})
+        with self.assertRaises(ValidationError):
+            self.env["auth.api.key"].\
+                _retrieve_uid_from_api_key("api_inactive_nok_key")
+
+    def test_user_inactive_not_specified(self):
+        demo_user = self.env.ref("base.user_demo")
+        demo_user.write({'active': False})
+        with self.assertRaises(ValidationError):
+            self.env["auth.api.key"].\
+                _retrieve_uid_from_api_key("api_inactive_off_key")


### PR DESCRIPTION
In some cases we use inactive user for technical purposes. To avoid any login in the web interface, these users are defined inactive.
If we want to use them for an API, it is impossible.
This PR aims to solve this case