### PR TITLE
[IMP] Handle xmlrpc Calls

### DIFF
--- a/auth_ldap_attribute_sync/models/res_company_ldap.py
+++ b/auth_ldap_attribute_sync/models/res_company_ldap.py
@@ -91,10 +91,10 @@ class CompanyLDAP(models.Model):
         return fields
 
     def _update_user(self, conf, user):
-        ldap_entry = self._get_ldap_user(
-            conf,
-            user.login
-        )
+        if not user:
+            ldap_entry = self._get_ldap_user(conf, self.env.user.login)
+        else:
+            ldap_entry = self._get_ldap_user(conf, user.login)
         if not ldap_entry:
             return ldap_entry
 
@@ -102,16 +102,10 @@ class CompanyLDAP(models.Model):
             'Updating field values from LDAP attributes for login "%s"',
             user.login
         )
-        fields = self._map_attributes_to_fields(
-            conf,
-            ldap_entry,
-            ['always']
-        )
+        fields = self._map_attributes_to_fields(conf, ldap_entry, ['always'])
 
         with registry(self.env.cr.dbname).cursor() as cr:
             env = api.Environment(cr, SUPERUSER_ID, {})
-
             SudoUser = env['res.users'].sudo()
             SudoUser.browse(user.id).write(fields)
-
         return ldap_entry


### PR DESCRIPTION
When trying to login via API call, the user variable being passed into the _update_user method returns False. When this happens the method uses the self.env.user variable to update the ldap_entry and the login is successful.