### PR TITLE
[12.0][IMP] ADD possibility to save api keys in database by using server_env

### DIFF
--- a/auth_api_key/__manifest__.py
+++ b/auth_api_key/__manifest__.py
@@ -12,6 +12,6 @@
     "website": "https://acsone.eu/",
     "development_status": "Beta",
     "depends": ["server_environment"],
-    "data": [],
+    "data": ['security/ir.model.access.csv'],
     "demo": [],
 }

--- a/auth_api_key/__manifest__.py
+++ b/auth_api_key/__manifest__.py
@@ -12,6 +12,6 @@
     "website": "https://acsone.eu/",
     "development_status": "Beta",
     "depends": ["server_environment"],
-    "data": ['security/ir.model.access.csv'],
+    "data": ['security/ir.model.access.csv', 'views/auth_api_key.xml'],
     "demo": [],
 }

--- a/auth_api_key/models/auth_api_key.py
+++ b/auth_api_key/models/auth_api_key.py
@@ -1,7 +1,7 @@
 # Copyright 2018 ACSONE SA/NV
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from odoo import api, models, tools, _
+from odoo import api, fields, models, tools, _
 
 from odoo.tools import consteq
 
@@ -15,52 +15,52 @@ class AuthApiKey(models.Model):
 
     name = fields.Char(required=True)
     key = fields.Char(required=True)
-    user = fields.Char(required=True)
-
-    _sql_constraints = [
-        ('key_uniq', 'unique(key)', 'API Key Retriever must be unique !'),
-    ]
+    user_id = fields.Many2one(
+        comodel_name="res.users",
+        string="User",
+        required=True)
 
     @property
     def _server_env_fields(self):
         base_fields = super()._server_env_fields
         api_key_fields = {
             "key": {},
-            "user": {},
         }
         api_key_fields.update(base_fields)
         return api_key_fields
 
     @api.model
-    @tools.ormcache("api_key")
-    def _retrieve_api_key(self, api_key):
-        if not self.env.user.has_group("base.group_system"):
-            raise AccessError(_("User is not allowed"))
-        ap_keys = self.search([])
-        # api key are a computed field in the context of server env
-        # so we can't use a domain in search method
-        key = False
-        for ap_key in ap_keys:
-            if consteq(api_key, ap_key.key):
-                key = ap_key
-
-        if not key:
-            raise ValidationError(
-                _("The key %s is not defined") % api_key)
-
-        return key
+    def _retrieve_api_key(self, key):
+        return self.browse(self._retrieve_api_key_id(key))
 
     @api.model
-    @tools.ormcache("api_key")
-    def _retrieve_uid_from_api_key(self, api_key):
-        ap_key = self._retrieve_api_key(api_key)
-        uid = self.env["res.users"].search(
-                    [("login", "=", ap_key.user)]).id
+    @tools.ormcache("key")
+    def _retrieve_api_key_id(self, key):
+        if not self.env.user.has_group("base.group_system"):
+            raise AccessError(_("User is not allowed"))
+        for api_key in self.search([]):
+            if consteq(key, api_key.key):
+                return api_key.id
+        raise ValidationError(_("The key %s is not allowed") % key)
 
-        if not uid:
-            raise ValidationError(
-                _("No user found with login %s") % ap_key.user)
+    @api.model
+    @tools.ormcache("key")
+    def _retrieve_uid_from_api_key(self, key):
+        return self._retrieve_api_key(key).user_id.id
 
-        return uid
-    return False
+    def _clear_key_cache(self):
+        self._retrieve_api_key_id.clear_cache()
+        self._retrieve_uid_from_api_key.clear_cache()
 
+    @api.model
+    def create(self, vals):
+        record = super(AuthApikey, self).create(vals)
+        if 'key' in vals:
+            self._clear_key_cache()
+        return record
+
+    def write(self, vals):
+        super(AuthApikey, self).write(vals)
+        if 'key' in vals:
+            self._clear_key_cache()
+        return True

--- a/auth_api_key/models/auth_api_key.py
+++ b/auth_api_key/models/auth_api_key.py
@@ -18,7 +18,10 @@ class AuthApiKey(models.Model):
     user_id = fields.Many2one(
         comodel_name="res.users",
         string="User",
-        required=True)
+        required=True,
+        help="""The user used to process the requests authenticated by
+        the api key"""
+    )
 
     @property
     def _server_env_fields(self):
@@ -49,18 +52,18 @@ class AuthApiKey(models.Model):
         return self._retrieve_api_key(key).user_id.id
 
     def _clear_key_cache(self):
-        self._retrieve_api_key_id.clear_cache()
-        self._retrieve_uid_from_api_key.clear_cache()
+        self._retrieve_api_key_id.clear_cache(self.env[self._name])
+        self._retrieve_uid_from_api_key.clear_cache(self.env[self._name])
 
     @api.model
     def create(self, vals):
-        record = super(AuthApikey, self).create(vals)
+        record = super(AuthApiKey, self).create(vals)
         if 'key' in vals:
             self._clear_key_cache()
         return record
 
     def write(self, vals):
-        super(AuthApikey, self).write(vals)
+        super(AuthApiKey, self).write(vals)
         if 'key' in vals:
             self._clear_key_cache()
         return True

--- a/auth_api_key/models/auth_api_key.py
+++ b/auth_api_key/models/auth_api_key.py
@@ -3,36 +3,64 @@
 
 from odoo import api, models, tools, _
 
-from odoo.addons.server_environment import serv_config
 from odoo.tools import consteq
 
 from odoo.exceptions import ValidationError, AccessError
 
 
-class AuthApiKey(models.TransientModel):
+class AuthApiKey(models.Model):
     _name = "auth.api.key"
+    _inherit = "server.env.mixin"
     _description = "API Key Retriever"
+
+    name = fields.Char(required=True)
+    key = fields.Char(required=True)
+    user = fields.Char(required=True)
+
+    _sql_constraints = [
+        ('key_uniq', 'unique(key)', 'API Key Retriever must be unique !'),
+    ]
+
+    @property
+    def _server_env_fields(self):
+        base_fields = super()._server_env_fields
+        api_key_fields = {
+            "key": {},
+            "user": {},
+        }
+        api_key_fields.update(base_fields)
+        return api_key_fields
+
+    @api.model
+    @tools.ormcache("api_key")
+    def _retrieve_api_key(self, api_key):
+        if not self.env.user.has_group("base.group_system"):
+            raise AccessError(_("User is not allowed"))
+        ap_keys = self.search([])
+        # api key are a computed field in the context of server env
+        # so we can't use a domain in search method
+        key = False
+        for ap_key in ap_keys:
+            if consteq(api_key, ap_key.key):
+                key = ap_key
+
+        if not key:
+            raise ValidationError(
+                _("The key %s is not defined") % api_key)
+
+        return key
 
     @api.model
     @tools.ormcache("api_key")
     def _retrieve_uid_from_api_key(self, api_key):
-        if not self.env.user.has_group("base.group_system"):
-            raise AccessError(_("User is not allowed"))
+        ap_key = self._retrieve_api_key(api_key)
+        uid = self.env["res.users"].search(
+                    [("login", "=", ap_key.user)]).id
 
-        for section in serv_config.sections():
-            if section.startswith("api_key_") and serv_config.has_option(
-                    section, "key"
-            ):
-                if not consteq(api_key, serv_config.get(section, "key")):
-                    continue
+        if not uid:
+            raise ValidationError(
+                _("No user found with login %s") % login_name)
 
-                login_name = serv_config.get(section, "user")
-                uid = self.env["res.users"].search(
-                    [("login", "=", login_name)]).id
+        return uid
+    return False
 
-                if not uid:
-                    raise ValidationError(
-                        _("No user found with login %s") % login_name)
-
-                return uid
-        return False

--- a/auth_api_key/models/auth_api_key.py
+++ b/auth_api_key/models/auth_api_key.py
@@ -59,7 +59,7 @@ class AuthApiKey(models.Model):
 
         if not uid:
             raise ValidationError(
-                _("No user found with login %s") % login_name)
+                _("No user found with login %s") % ap_key.user)
 
         return uid
     return False

--- a/auth_api_key/models/ir_http.py
+++ b/auth_api_key/models/ir_http.py
@@ -22,16 +22,16 @@ class IrHttp(models.AbstractModel):
         api_key = headers.get("HTTP_API_KEY")
         if api_key:
             request.uid = 1
-            uid = request.env["auth.api.key"]._retrieve_uid_from_api_key(
-                api_key)
-            if uid:
+            api = request.env["auth.api.key"]._retrieve_api_key(api_key)
+            if api:
                 # reset _env on the request since we change the uid...
                 # the next call to env will instantiate an new
                 # odoo.api.Environment with the user defined on the
                 # auth.api_key
                 request._env = None
-                request.uid = uid
+                request.uid = api.user_id.id
                 request.auth_api_key = api_key
+                request.auth_api_key_id = api.id
                 return True
         _logger.error("Wrong HTTP_API_KEY, access denied")
         raise AccessDenied()

--- a/auth_api_key/readme/CONFIGURE.rst
+++ b/auth_api_key/readme/CONFIGURE.rst
@@ -1,10 +1,11 @@
-The api key must be provided by the configuration parameter named
-'api_key_*.key', and the user under the same option 'api_key_*.user'.
-
-For instance :
+The api key menu is available into Settings > Technical in debug mode.
+By default, when you create an API key, the key is saved into the database.
+It is also possible to provide the value of this key via the configuration
+file. This can be very useful to avoid mixing your keys between your various
+environments when restoring databases. All you have to do is to add a new
+section to your configuration file according to the following convention:
 
 .. code-block:: ini
 
-    [api_key_mykey]
+    [auth_api_key.<Record Name>]
     key=my_api_key
-    user=my_user

--- a/auth_api_key/security/ir.model.access.csv
+++ b/auth_api_key/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_auth_api_key,access_auth_api_key,model_auth_api_key,base.group_system,1,1,1,1

--- a/auth_api_key/views/auth_api_key.xml
+++ b/auth_api_key/views/auth_api_key.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record model="ir.ui.view" id="auth_api_key_form_view">
+        <field name="name">auth.api.key.form (in auth_api_key)</field>
+        <field name="model">auth.api.key</field>
+        <field name="arch" type="xml">
+            <form create="false" edit="false">
+                <sheet>
+                    <label for="name" class="oe_edit_only"/>
+                    <h1>
+                        <field name="name" class="oe_inline"/>
+                    </h1>
+                     <group name="config" colspan="4" col="4">
+                         <field name="user_id" colspan="4"/>
+                         <field name="key"  colspan="4"/>
+                     </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+
+    <record model="ir.ui.view" id="auth_api_key_tree_view">
+        <field name="name">auth.api.key.tree (in auth_api_key)</field>
+        <field name="model">auth.api.key</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="user_id"/>
+            </tree>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="auth_api_key_act_window">
+        <field name="name">Auth Api Key</field>
+        <field name="res_model">auth.api.key</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[]</field>
+        <field name="context">{}</field>
+    </record>
+
+    <record model="ir.ui.menu" id="auth_api_key_menu">
+        <field name="name">Auth Api Key</field>
+        <field name="parent_id" ref="base.menu_custom"/>
+        <field name="action" ref="auth_api_key_act_window"/>
+        <field name="sequence" eval="100"/>
+    </record>
+
+</odoo>


### PR DESCRIPTION
ADD possibility to save api keys in database by using server.env.mixin obj

TODO
- [ ] add key generation
- [ ] option for inactive/active user
- [x] fix test
