### PR TITLE
[11.0][FIX] missing package in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
     packages:
       - expect-dev  # provides unbuffer utility
       - python-lxml # because pip installation is slow
+      - libmysqlclient-dev # To install mysqlclient and import MySQLdb
 
 env:
   global:


### PR DESCRIPTION
Added - libmysqlclient-dev # To install mysqlclient and import MySQLdb and fix missing dependency