### PR TITLE
[FIX] [11.0] password_security - redirection fails when password_secu…

### DIFF
--- a/password_security/controllers/main.py
+++ b/password_security/controllers/main.py
@@ -43,6 +43,8 @@ class PasswordSecurityHome(AuthSignupHome):
         # My password is expired, kick me out
         request.env.user.action_expire_password()
         request.session.logout(keep_db=True)
+        # I was kicked out, so set login_success in request params to False
+        request.params['login_success'] = False
         redirect = request.env.user.partner_id.signup_url
         return http.redirect_with_hash(redirect)
 


### PR DESCRIPTION
This PR fixes the redirection to reset password page when the logging in user's password is expired.

'login_success' param is set in request params when the user successfully logged in. This is introduced in the commit https://github.com/odoo/odoo/commit/a1fac87d2509498148d8649f0eb703238e86a4e2 to redirect the user to backend or front end based on their access rights.

As we kick out the user when the logging in user's password is expired, we can set the 'login_success' param to False. This will avoid the redirection in the website module controller and will redirect us to password reset page.

This PR fixes https://github.com/OCA/server-auth/issues/119.