### PR TITLE
[FIX] auth_saml: Fix KeyError using auth_oauth module.

### DIFF
--- a/auth_saml/controllers/main.py
+++ b/auth_saml/controllers/main.py
@@ -57,7 +57,10 @@ class SAMLLogin(Home):
         except Exception as e:
             _logger.exception("SAML2: %s" % str(e))
             providers = []
-
+        for provider in providers:
+            # Compatibility with auth_oauth/controllers/main.py in order to
+            # avoid KeyError rendering template_auth_oauth_providers
+            provider['auth_link'] = ""
         return providers
 
     @http.route()


### PR DESCRIPTION
The following line of code for 11.0:
 - https://github.com/odoo/odoo/blob/52d6f0e3ee90874fc93fec9cdff74ec71d3b991f/addons/auth_oauth/controllers/main.py#L69

is assigning the key "auth_link" for "list_providers" method.

The following template is expecting this key:
 - https://github.com/odoo/odoo/blob/52d6f0e3ee90874fc93fec9cdff74ec71d3b991f/addons/auth_oauth/views/auth_oauth_templates.xml#L5

So, it raise a KeyError compiling "template_auth_oauth_providers_N"

This change is fixing adding that expected key in order to avoid this
KeyError

The following PR by @eilst is red because of this error:
 - https://github.com/OCA/server-auth/pull/113

Check the following output:
 - https://travis-ci.org/OCA/server-auth/jobs/616860206#L1650