### PR TITLE
[FIX] password_security: translatable error message

### DIFF
--- a/password_security/i18n/es.po
+++ b/password_security/i18n/es.po
@@ -6,16 +6,46 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-22 00:55+0000\n"
-"PO-Revision-Date: 2020-02-06 12:13+0000\n"
+"POT-Creation-Date: 2020-02-14 10:15+0000\n"
+"PO-Revision-Date: 2020-02-14 10:39+0000\n"
 "Last-Translator: Jairo Llopis <jairo.llopis@tecnativa.com>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.10\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.2.4\n"
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:53
+#, python-format
+msgid "* %d lowercase characters."
+msgstr "* %d letras minúsculas."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:61
+#, python-format
+msgid "* %d numbers."
+msgstr "* %d números."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:65
+#, python-format
+msgid "* %d special characters."
+msgstr "* %d caracteres especiales."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:57
+#, python-format
+msgid "* %d uppercase characters."
+msgstr "* %d letras mayúsculas."
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:69
+#, python-format
+msgid "* A length of at least %d characters."
+msgstr "* Una longitud de al menos %d caracteres."
 
 #. module: password_security
 #: model:ir.model.fields,help:password_security.field_res_company_password_minimum
@@ -23,7 +53,7 @@ msgid "Amount of hours until a user may change password again"
 msgstr "Número de horas antes que un usuario pueda cambiar la contraseña"
 
 #. module: password_security
-#: code:addons/password_security/models/res_users.py:156
+#: code:addons/password_security/models/res_users.py:161
 #, python-format
 msgid "Cannot use the most recent %d passwords"
 msgstr "No se puede utilizar una de las %d contraseñas más recientes"
@@ -133,7 +163,7 @@ msgid "Minimum number of characters"
 msgstr "Número mínimo de caracteres"
 
 #. module: password_security
-#: code:addons/password_security/models/res_users.py:64
+#: code:addons/password_security/models/res_users.py:50
 #, python-format
 msgid "Must contain the following:"
 msgstr "Debe contener lo siguiente:"
@@ -154,7 +184,7 @@ msgid "Password Policy"
 msgstr "Política de Contraseñas"
 
 #. module: password_security
-#: code:addons/password_security/models/res_users.py:133
+#: code:addons/password_security/models/res_users.py:138
 #, python-format
 msgid ""
 "Passwords can only be reset every %d hour(s). Please contact an "
@@ -171,7 +201,7 @@ msgstr "Requerir esta cantidad de letras minúsculas"
 #. module: password_security
 #: model:ir.model.fields,help:password_security.field_res_company_password_numeric
 msgid "Require number of numeric digits"
-msgstr "Requerir esta cantidad de dígitos numéricos"
+msgstr "Requerir esta cantidad de números"
 
 #. module: password_security
 #: model:ir.model.fields,help:password_security.field_res_company_password_special
@@ -217,18 +247,3 @@ msgstr "Usuario"
 #: model:ir.model,name:password_security.model_res_users
 msgid "Users"
 msgstr "Usuarios"
-
-#~ msgid "Lowercase letter"
-#~ msgstr "Letra minúscula"
-
-#~ msgid "Numeric digit"
-#~ msgstr "Dígito numérico"
-
-#~ msgid "Password must be %d characters or more."
-#~ msgstr "La contraseña debe ser de al menos %d caracteres."
-
-#~ msgid "Special character"
-#~ msgstr "Caracteres especiales"
-
-#~ msgid "Uppercase letter"
-#~ msgstr "Letra mayúscula"

--- a/password_security/i18n/password_security.pot
+++ b/password_security/i18n/password_security.pot
@@ -1,11 +1,13 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* password_security
+#       * password_security
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-02-14 10:15+0000\n"
+"PO-Revision-Date: 2020-02-14 10:15+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -14,12 +16,42 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: password_security
+#: code:addons/password_security/models/res_users.py:53
+#, python-format
+msgid "* %d lowercase characters."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:61
+#, python-format
+msgid "* %d numbers."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:65
+#, python-format
+msgid "* %d special characters."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:57
+#, python-format
+msgid "* %d uppercase characters."
+msgstr ""
+
+#. module: password_security
+#: code:addons/password_security/models/res_users.py:69
+#, python-format
+msgid "* A length of at least %d characters."
+msgstr ""
+
+#. module: password_security
 #: model:ir.model.fields,help:password_security.field_res_company_password_minimum
 msgid "Amount of hours until a user may change password again"
 msgstr ""
 
 #. module: password_security
-#: code:addons/password_security/models/res_users.py:156
+#: code:addons/password_security/models/res_users.py:161
 #, python-format
 msgid "Cannot use the most recent %d passwords"
 msgstr ""
@@ -125,7 +157,7 @@ msgid "Minimum number of characters"
 msgstr ""
 
 #. module: password_security
-#: code:addons/password_security/models/res_users.py:64
+#: code:addons/password_security/models/res_users.py:50
 #, python-format
 msgid "Must contain the following:"
 msgstr ""
@@ -146,7 +178,7 @@ msgid "Password Policy"
 msgstr ""
 
 #. module: password_security
-#: code:addons/password_security/models/res_users.py:133
+#: code:addons/password_security/models/res_users.py:138
 #, python-format
 msgid "Passwords can only be reset every %d hour(s). Please contact an administrator for assistance."
 msgstr ""
@@ -205,4 +237,3 @@ msgstr ""
 #: model:ir.model,name:password_security.model_res_users
 msgid "Users"
 msgstr ""
-

--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -47,26 +47,31 @@ class ResUsers(models.Model):
     def password_match_message(self):
         self.ensure_one()
         company_id = self.company_id
-        message = []
+        message = [_('Must contain the following:')]
         if company_id.password_lower:
-            message.append('\n* ' + 'Lowercase letter (At least ' + str(
-                company_id.password_lower) + ' character)')
+            message.append(
+                _("* %d lowercase characters.") % company_id.password_lower
+            )
         if company_id.password_upper:
-            message.append('\n* ' + 'Uppercase letter (At least ' + str(
-                company_id.password_upper) + ' character)')
+            message.append(
+                _("* %d uppercase characters.") % company_id.password_upper
+            )
         if company_id.password_numeric:
-            message.append('\n* ' + 'Numeric digit (At least ' + str(
-                company_id.password_numeric) + ' character)')
+            message.append(
+                _("* %d numbers.") % company_id.password_numeric
+            )
         if company_id.password_special:
-            message.append('\n* ' + 'Special character (At least ' + str(
-                company_id.password_special) + ' character)')
-        if message:
-            message = [_('Must contain the following:')] + message
+            message.append(
+                _("* %d special characters.") % company_id.password_special
+            )
         if company_id.password_length:
-            message = ['Password must be %d characters or more.' %
-                       company_id.password_length
-                       ] + message
-        return '\r'.join(message)
+            message.append(
+                _("* A length of at least %d characters.") %
+                company_id.password_length
+            )
+        if len(message) == 1:
+            return ""
+        return '\n'.join(message)
 
     @api.multi
     def _check_password(self, password):


### PR DESCRIPTION
Without this patch, users must know English to understand why they cannot change their passwords.

@Tecnativa TT21381