### PR TITLE
[11.0][ADD] group mapping pre validation before creating user

### DIFF
--- a/auth_saml_groups/views/auth_saml.xml
+++ b/auth_saml_groups/views/auth_saml.xml
@@ -8,6 +8,7 @@
             <xpath expr="//field[@name='sp_pkey']/.." position="after">
              <group string="Map User Groups" >   
                 <field name="only_saml_groups"/>
+                <field name = "create_user_if_mapping"/>
                 <label for="group_mapping_ids" />
                     <field name="group_mapping_ids" nolabel="1">
                         <tree editable="bottom">


### PR DESCRIPTION
Add option to validate group mapping before creating users.
At this time if users exist in the idp (identity provider), they will be created in odoo. Even if there
are no group mappings, i.e. user in odoo whitout any group.
So with this new field, administrators will be able to prevent users with no group mappings to be created in odoo.
![Local Authentic server - Odoo](https://user-images.githubusercontent.com/12146356/74596013-18dfa000-5017-11ea-8867-93dbdbb8a84b.png)
