### PR TITLE
[FIX] auth_signup_verify_email: make tests compatible with website

### DIFF
--- a/auth_signup_verify_email/tests/test_verify_email.py
+++ b/auth_signup_verify_email/tests/test_verify_email.py
@@ -10,12 +10,15 @@ from odoo.tools.misc import mute_logger
 
 class UICase(HttpCase):
     def setUp(self):
-        super(UICase, self).setUp()
-        with self.cursor() as cr:
-            env = self.env(cr)
-            icp = env["ir.config_parameter"]
-            icp.set_param("auth_signup.allow_uninvited", "True")
-
+        super().setUp()
+        if "website" in self.env:
+            # Enable public signup in website if it is installed; otherwise
+            # tests here would fail
+            current_website = self.env['website'].get_current_website()
+            current_website.auth_signup_uninvited = "b2c"
+        self.env["ir.config_parameter"].set_param(
+            "auth_signup.invitation_scope", "b2c"
+        )
         self.data = {
             "csrf_token": self.csrf_token(),
             "name": "Somebody",


### PR DESCRIPTION
This commit fixes 2 problems:

1.  `auth_signup.allow_uninvited` ICP is no longer used.
    The new equivalent is `auth_signup.invitation_scope=b2c`.
2.  If running tests in an environment where `website` is installed,
    the website needs to get public signup enabled or tests here would
    fail with an error like this:

        2020-02-19 12:36:31,686 35 INFO prod odoo.modules.module: odoo.addons.auth_signup_verify_email.tests.test_verify_email running tests.
        2020-02-19 12:36:31,686 35 INFO prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: test_bad_email (odoo.addons.auth_signup_verify_email.tests.test_verify_email.UICase)
        2020-02-19 12:36:31,686 35 INFO prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: ` Test rejection of bad emails.
        2020-02-19 12:36:31,735 35 INFO ? odoo.http: HTTP Configuring static files
        2020-02-19 12:36:31,738 35 INFO prod odoo.addons.base.models.ir_http: Generating routing map
        2020-02-19 12:36:34,227 35 INFO prod werkzeug: 127.0.0.1 - - [19/Feb/2020 12:36:34] "GET /web/signup HTTP/1.1" 404 - 763 0.262 2.227
        2020-02-19 12:36:34,231 35 ERROR prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: ERROR
        2020-02-19 12:36:34,231 35 INFO prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: test_good_email (odoo.addons.auth_signup_verify_email.tests.test_verify_email.UICase)
        2020-02-19 12:36:34,231 35 INFO prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: ` Test acceptance of good emails.
        2020-02-19 12:36:36,293 35 INFO prod werkzeug: 127.0.0.1 - - [19/Feb/2020 12:36:36] "GET /web/signup HTTP/1.1" 404 - 759 0.258 1.797
        2020-02-19 12:36:36,296 35 ERROR prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: ERROR
        2020-02-19 12:36:36,297 35 INFO prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: ======================================================================
        2020-02-19 12:36:36,297 35 ERROR prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: ERROR: test_bad_email (odoo.addons.auth_signup_verify_email.tests.test_verify_email.UICase)
        2020-02-19 12:36:36,297 35 ERROR prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: ` Test rejection of bad emails.
        2020-02-19 12:36:36,297 35 ERROR prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: Traceback (most recent call last):
        2020-02-19 12:36:36,297 35 ERROR prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: `   File "/opt/odoo/auto/addons/auth_signup_verify_email/tests/test_verify_email.py", line 20, in setUp
        2020-02-19 12:36:36,297 35 ERROR prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: `     "csrf_token": self.csrf_token(),
        2020-02-19 12:36:36,297 35 ERROR prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: `   File "/opt/odoo/auto/addons/auth_signup_verify_email/tests/test_verify_email.py", line 33, in csrf_token
        2020-02-19 12:36:36,297 35 ERROR prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: `     return doc.xpath("//input[@name='csrf_token']")[0].get("value")
        2020-02-19 12:36:36,297 35 ERROR prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: ` IndexError: list index out of range
        2020-02-19 12:36:36,297 35 INFO prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: ======================================================================
        2020-02-19 12:36:36,298 35 ERROR prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: ERROR: test_good_email (odoo.addons.auth_signup_verify_email.tests.test_verify_email.UICase)
        2020-02-19 12:36:36,298 35 ERROR prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: ` Test acceptance of good emails.
        2020-02-19 12:36:36,298 35 ERROR prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: Traceback (most recent call last):
        2020-02-19 12:36:36,298 35 ERROR prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: `   File "/opt/odoo/auto/addons/auth_signup_verify_email/tests/test_verify_email.py", line 20, in setUp
        2020-02-19 12:36:36,298 35 ERROR prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: `     "csrf_token": self.csrf_token(),
        2020-02-19 12:36:36,298 35 ERROR prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: `   File "/opt/odoo/auto/addons/auth_signup_verify_email/tests/test_verify_email.py", line 33, in csrf_token
        2020-02-19 12:36:36,298 35 ERROR prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: `     return doc.xpath("//input[@name='csrf_token']")[0].get("value")
        2020-02-19 12:36:36,298 35 ERROR prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: ` IndexError: list index out of range
        2020-02-19 12:36:36,298 35 INFO prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: Ran 2 tests in 4.611s
        2020-02-19 12:36:36,298 35 ERROR prod odoo.addons.auth_signup_verify_email.tests.test_verify_email: FAILED
        2020-02-19 12:36:36,298 35 INFO prod odoo.addons.auth_signup_verify_email.tests.test_verify_email:  (errors=2)
        2020-02-19 12:36:36,298 35 ERROR prod odoo.modules.module: Module auth_signup_verify_email: 0 failures, 2 errors

@Tecnativa TT21005