### PR TITLE
[FIX] auth_totp: Use binary field for QR code instead of html field.

### DIFF
--- a/auth_totp/__manifest__.py
+++ b/auth_totp/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'MFA Support',
     'summary': 'Allows users to enable MFA and add optional trusted devices',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.0.1',
     'category': 'Tools',
     'website': 'https://github.com/OCA/server-auth',
     'author': 'LasLabs, Odoo Community Association (OCA)',

--- a/auth_totp/tests/test_res_users_authenticator_create.py
+++ b/auth_totp/tests/test_res_users_authenticator_create.py
@@ -1,5 +1,6 @@
 # Copyright 2016-2017 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+import base64
 
 import mock
 from odoo.exceptions import ValidationError
@@ -66,11 +67,15 @@ class TestResUsersAuthenticatorCreate(TransactionCase):
         """Should set field to image with encoded PyOTP URI if user present"""
         pyotp_mock.TOTP().provisioning_uri.return_value = 'test:uri'
         test_wiz = self._new_wizard()
-
+        barcode = self.env['ir.actions.report'].barcode(
+            'QR',
+            value='test:uri',
+            width=300,
+            height=300,
+        )
         self.assertEqual(
             test_wiz.qr_code_tag,
-            '<img src="/report/barcode/?type=QR&amp;value='
-            '%s&amp;width=300&amp;height=300">' % 'test:uri',
+            base64.b64encode(barcode),
         )
 
     def test_compute_qr_code_tag_pyotp_use(self, pyotp_mock):

--- a/auth_totp/wizards/res_users_authenticator_create.xml
+++ b/auth_totp/wizards/res_users_authenticator_create.xml
@@ -13,6 +13,9 @@
             <form string="Authenticator Info">
                 <header/>
                 <sheet>
+                    <field name="qr_code_tag" widget="image"
+                           class="oe_avatar"
+                           options="{'size': [150, 150]}"/>
                     <div>
                         <span>Please provide a name for your app/device. </span>
                         <span>Then scan the QR code or enter the secret code below to add this account to your authenticator app and enter in the six digit code produced by the app.</span>
@@ -20,8 +23,7 @@
                     <group name="data">
                         <field name="name"/>
                         <field name="user_id"/>
-                        <field name="secret_key" readonly="1"/>
-                        <field name="qr_code_tag"/>
+                        <field name="secret_key" force_save="1" readonly="1"/>
                         <field name="confirmation_code"/>
                     </group>
                 </sheet>


### PR DESCRIPTION
Issue:
The HTML field fails to display the QR code.

Steps
* Open MFA App/Device Creation Wizard

Result
* Form is show, but QR code field is blank

Expected:
* QR code field is show

This PR also contains a fix for #140

* adds force_save to the secret_key form field;  fixes  
