### PR TITLE
[FIX] users_ldap_populate: use str, not bytes

### DIFF
--- a/users_ldap_populate/models/users_ldap.py
+++ b/users_ldap_populate/models/users_ldap.py
@@ -124,13 +124,13 @@ class CompanyLDAP(models.Model):
         ldap_password = conf['ldap_password'] or ''
         ldap_binddn = conf['ldap_binddn'] or ''
         conn.simple_bind_s(
-            ldap_binddn.encode('utf-8'),
-            ldap_password.encode('utf-8')
+            ldap_binddn,
+            ldap_password
         )
         results = conn.search_st(
-            conf['ldap_base'].encode('utf-8'),
+            conf['ldap_base'],
             ldap.SCOPE_SUBTREE,
-            ldap_filter.encode('utf8'),
+            ldap_filter,
             None,
             timeout=timeout
         )
@@ -173,7 +173,7 @@ class CompanyLDAP(models.Model):
         conn.simple_bind_s(conf['ldap_binddn'] or '',
                            conf['ldap_password'] or '')
         results = conn.search_st(conf['ldap_base'], ldap.SCOPE_SUBTREE,
-                                 ldap_filter.encode('utf8'), None,
+                                 ldap_filter, None,
                                  timeout=60)
         conn.unbind()
 

--- a/users_ldap_populate/tests/test_users_ldap_populate.py
+++ b/users_ldap_populate/tests/test_users_ldap_populate.py
@@ -12,7 +12,7 @@ class PatchLDAPConnection(object):
         return True
 
     def search_st(self, base, scope, ldap_filter, attributes, timeout=None):
-        if ldap_filter.decode() == '(uid=*)':
+        if ldap_filter == '(uid=*)':
             return self.results
         else:
             return []


### PR DESCRIPTION
Without this fix, when hitting the populate button, Odoo failed with:

```
 Odoo Server Error

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 656, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 314, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/opt/odoo/custom/src/odoo/odoo/tools/pycompat.py", line 87, in reraise
    raise value
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 698, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 346, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 97, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 339, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 941, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 519, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 966, in call_button
    action = self._call_kw(model, method, args, {})
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 954, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 759, in call_kw
    return _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 746, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/auto/addons/users_ldap_populate/models/users_ldap.py", line 189, in populate_wizard
    res_id = wizard_obj.create({'ldap_id': self.id}).id
  File "<decorator-gen-155>", line 2, in create
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 461, in _model_create_multi
    return create(self, [arg])
  File "/opt/odoo/auto/addons/users_ldap_populate/models/populate_wizard.py", line 32, in create
    ldap.action_populate()
  File "/opt/odoo/auto/addons/users_ldap_populate/models/users_ldap.py", line 65, in action_populate
    results = self._get_ldap_entry_dicts(conf)
  File "/opt/odoo/auto/addons/users_ldap_populate/models/users_ldap.py", line 128, in _get_ldap_entry_dicts
    ldap_password.encode('utf-8')
  File "/usr/local/lib/python3.7/site-packages/ldap/ldapobject.py", line 382, in simple_bind_s
    msgid = self.simple_bind(who,cred,serverctrls,clientctrls)
  File "/usr/local/lib/python3.7/site-packages/ldap/ldapobject.py", line 376, in simple_bind
    return self._ldap_call(self._l.simple_bind,who,cred,RequestControlTuples(serverctrls),RequestControlTuples(clientctrls))
  File "/usr/local/lib/python3.7/site-packages/ldap/ldapobject.py", line 263, in _ldap_call
    result = func(*args,**kwargs)
TypeError: argument 1 must be str, not bytes
```

@Tecnativa TT23686