### PR TITLE
[12.0][FIX] Remove force expired session

### DIFF
--- a/auth_session_timeout/models/res_users.py
+++ b/auth_session_timeout/models/res_users.py
@@ -76,8 +76,6 @@ class ResUsers(models.Model):
                 _logger.exception(
                     'Exception reading session file modified time.',
                 )
-                # Force expire the session. Will be resolved with new session.
-                expired = True
 
         # Try to terminate the session
         terminated = False


### PR DESCRIPTION
Forcing the expired to true in case session or modified time could not be found causes that user is always brought to login page in case session could not be find.

This is problematic for a number of cases, including reset_password used for first connection, or for accessing public surveys for instance, and probably also for accessing any public element which should not be redirected to login page...

This PR proposes to keep expired=False in case exception is raised while looking for modified time on session (meaning that either session does not exist or does not have a modified time - although this second case should not be possible afaik)