### PR TITLE
[12.0][FIX] make the auth_api_key editable

### DIFF
--- a/auth_api_key/views/auth_api_key.xml
+++ b/auth_api_key/views/auth_api_key.xml
@@ -8,7 +8,7 @@
         <field name="name">auth.api.key.form (in auth_api_key)</field>
         <field name="model">auth.api.key</field>
         <field name="arch" type="xml">
-            <form create="false" edit="false">
+            <form>
                 <sheet>
                     <label for="name" class="oe_edit_only"/>
                     <h1>


### PR DESCRIPTION
Since V12 server env allow to edit the value if not server_env_file havebeen defined.
This also solve compatibility issue with server_environment_data_encryption
@lmignon @rousseldenis 