### PR TITLE
[FIX] auth_saml: commit transaction after check saml

### DIFF
--- a/auth_saml/controllers/main.py
+++ b/auth_saml/controllers/main.py
@@ -174,6 +174,7 @@ class AuthSAMLController(http.Controller):
                 credentials = env['res.users'].sudo().auth_saml(
                     provider, saml_response
                 )
+                cr.commit()
                 action = state.get('a')
                 menu = state.get('m')
                 url = '/'


### PR DESCRIPTION
`login_and_redirect` uses new transaction, but transaction in origin controller isn't commit yet and tokens in `auth_saml.token` aren't visible in `_check_credentials` method.

Seems that code was lost while migrate from 11.0 branch: https://github.com/OCA/server-auth/blob/11.0/auth_saml/controllers/main.py#L185