### PR TITLE
[12.0][FIX] password_security: Log password history without writing on user

### DIFF
--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -205,4 +205,7 @@ class ResUsers(models.Model):
         """ It saves password crypt history for history rules """
         super(ResUsers, self)._set_encrypted_password(uid, pw)
 
-        self.write({"password_history_ids": [(0, 0, {"password_crypt": pw})]})
+        self.env["res.users.pass.history"].create({
+            "user_id": uid,
+            "password_crypt": pw
+        })

--- a/password_security/readme/CONTRIBUTORS.rst
+++ b/password_security/readme/CONTRIBUTORS.rst
@@ -4,3 +4,4 @@
 * Petar Najman <petar.najman@modoolar.com>
 * Shepilov Vladislav <shepilov.v@protonmail.com>
 * Florian Kantelberg <florian.kantelberg@initos.com>
+* Andrea Stirpe <a.stirpe@onestein.nl>


### PR DESCRIPTION
When a user does a first login, method `_set_encrypted_password()` is executed.
Module `password_security` extends `_set_encrypted_password()` in order to save the new encrypted password in the password history.

In case the write permissions on `res.users` model is protected by some access rules, for example for users with low level access permissions, the following line:

```python
    self.write({"password_history_ids": [(0, 0, {"password_crypt": pw})]})
```

will raise an error, because it attempts to write field `password_history_ids` on the user record.

The proposed fix consists in just adding a record in the password history without writing directly on `res.user`.

