### PR TITLE
[12.0] FIX auth_saml when reading/writing config_parameter: False values are not stored

### DIFF
--- a/auth_saml/models/res_users.py
+++ b/auth_saml/models/res_users.py
@@ -237,6 +237,6 @@ class ResUser(models.Model):
         """Know if both SAML and local password auth methods can coexist."""
         return tools.str2bool(
             self.env['ir.config_parameter'].sudo().get_param(
-                'auth_saml.allow_saml.uid_and_internal_password', 'True'
+                'auth_saml.allow_saml.uid_and_internal_password', 'False'
             )
         )


### PR DESCRIPTION
Also, the default value should be False anyway, for security