### PR TITLE
[FIX] auth_signup_verify_email: Handle errors in qcontext

### DIFF
--- a/auth_signup_verify_email/controllers/main.py
+++ b/auth_signup_verify_email/controllers/main.py
@@ -24,6 +24,12 @@ class SignupVerifyEmail(AuthSignupHome):
         values = request.params
         qcontext = self.get_auth_signup_qcontext()
 
+        if 'error' in qcontext and request.httprequest.method == 'POST':
+            # Stop and show error if error was detected in qcontext
+            # This is required to be compatible with other modules, that
+            # override qcontext to add some pre-processing of signup
+            return request.render("auth_signup.signup", qcontext)
+
         # Check good format of e-mail
         try:
             validate_email(values.get("login", ""))


### PR DESCRIPTION
This fix is mostly for compatability with other modules.
The standard Odoo code handles the case, when error is detected by method
`get_auth_signup_qcontext', but before this commit this module breaks
this bechavior.

So, this commit adds handling for case, when error is detected by
`get_auth_signup_qcontext`, that could be overridden by other modul.

The case, when other module overrides `web_auth_signup` method, will not
reliably work, because it is not defined which method override will be
called first (implmented in this (auth_signup_verify_email) module or in
other module).

The example of such third-party module could be module, that have to add
recaptcha integration (with backend validation) to signup page.