### PR TITLE
[12.0] auth_session_timeout fails with missing session files

### DIFF
--- a/auth_session_timeout/models/res_users.py
+++ b/auth_session_timeout/models/res_users.py
@@ -4,7 +4,7 @@
 
 import logging
 
-from os.path import getmtime
+from os.path import getmtime, exists
 from time import time
 from os import utime
 
@@ -70,8 +70,10 @@ class ResUsers(models.Model):
         if deadline is not False:
             path = http.root.session_store.get_session_filename(session.sid)
             try:
-
-                expired = getmtime(path) < deadline
+                if exists(path):
+                    expired = getmtime(path) < deadline
+                else:
+                    expired = True
             except OSError:
                 _logger.exception(
                     'Exception reading session file modified time.',


### PR DESCRIPTION
The change is mostly to check for the existence of a file.
The current code tests against mocks but never test if a file exists or not. I added a new test that check if the file doesn't exist then it will not crash and just raise a SessionExpired.

We had an issue on one of our server with this module today. For some reasons, the file returned by the session store would not exist. In reality the filename returned is only based on a sid and session store path so it's quite possible that a session file doesn't exist.

The issue is caused because getmtime raised a FileNotFoundError... I'm a bit surprised the current code doesn't work because a FileNotFoundError is in fact an OSError. I could fix the issue by checking if the file actually exist before calling getmtime on it.

Maybe the error is platform specific while rather strange. Checking if a file exists might still prevent raising an exception for nothing. 