### PR TITLE
[12.0][FIX] server_auth: remove bad dependency and update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,16 @@ cache: pip
 python:
   - "3.5"
 
+virtualenv:
+  system_site_packages: true
+
 addons:
   postgresql: "9.6"
   apt:
     packages:
       - expect-dev  # provides unbuffer utility
       - python-lxml # because pip installation is slow
+      - python3-lasso  # because there is not pypi package
 
 stages:
   - linting

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,3 @@ email_validator
 python-u2flib-server
 # password_security
 zxcvbn
-# auth_saml
-lasso


### PR DESCRIPTION

Description of the issue/feature this PR addresses:

lasso on external_dependencies is wrong, https://pypi.org/project/lasso/ dont implement any thing about saml and generate conflicts with correct library python3-lasso, official reference of the lasso https://pypi.org/project/lasso/ is precising that it's an alpha stage and moreover when you follow the doc and you want to point to the https://github.com/aperezdc/lasso-python it has been renamed in gnarl, also python-lasso has not a description and to point to https://github.com/lasso-gmbh/lasso-python, that is a not related project.

python3-lasso comes from https://ubuntuupdates.org/package/core/bionic/universe/updates/python3-lasso

More information:

https://github.com/OCA/server-auth/issues/20#issuecomment-689881797
https://github.com/OCA/server-auth/issues/207
https://github.com/OCA/server-auth/issues/195#issuecomment-625168995

Current behavior before PR: errors with lasso library.

Desired behavior after PR is merged: no errors related with lasso shown.

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
