### PR TITLE
[FIX] password_security: Increase timeout in tests

### DIFF
--- a/password_security/tests/test_password_security_home.py
+++ b/password_security/tests/test_password_security_home.py
@@ -241,6 +241,7 @@ class LoginCase(HttpCase):
         response = self.url_open(
             "/web/login",
             {"login": "admin", "password": "admin"},
+            timeout=30,
         )
         # Password has expired, I'm redirected to reset it
         all_urls = [call[0][0] for call in redirect_mock.call_args_list


### PR DESCRIPTION
Timeout is hit when performing the login if the environment has a complex qweb reports recordset that needs to be loaded.
The issue is especially relevant in a CI environment with tests from other modules.

@Tecnativa
TT28141

ping @pedrobaeza @Yajo 