### PR TITLE
[13.0][IMP] auth_from_http_remote_user: update last login

### DIFF
--- a/auth_from_http_remote_user/controllers/main.py
+++ b/auth_from_http_remote_user/controllers/main.py
@@ -74,6 +74,7 @@ class Home(main.Home):
             request.session.authenticate(
                 db_name, login=login, password=key, uid=user.id
             )
+            user.with_user(user=user)._update_last_login()
         except http.AuthenticationError:
             raise
         except Exception:


### PR DESCRIPTION
Without this, last login date is never set and user is blocked to state *Never connected*.