### PR TITLE
[12.0][IMP]auth_admin_passkey: Block loggin using admin passkey with some users.

### DIFF
--- a/auth_admin_passkey/__manifest__.py
+++ b/auth_admin_passkey/__manifest__.py
@@ -11,7 +11,11 @@
     'website': 'https://www.github.com/OCA/server-auth',
     'license': 'AGPL-3',
     'depends': [
+        'base',
         'mail',
+    ],
+    'data': [
+        'views/res_users_views.xml',
     ],
     'installable': True,
 }

--- a/auth_admin_passkey/readme/CONFIGURE.rst
+++ b/auth_admin_passkey/readme/CONFIGURE.rst
@@ -30,3 +30,6 @@ No keys to add.
     auth_admin_passkey_send_to_user = True
     auth_admin_passkey_sysadmin_email = SYSADMIN_PASSWORD
     auth_admin_passkey_sysadmin_lang = SYSADMIN_LANG
+
+* To avoid the usage of the admin passkey with some users go to the User record
+  and check the "Block Admin Passkey" checkbox.

--- a/auth_admin_passkey/readme/CONTRIBUTORS.rst
+++ b/auth_admin_passkey/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Eugen Don <eugen.don@don-systems.de>
 * Alexandre Papin (https://twitter.com/Fenkiou)
 * Sylvain LE GAL (https://twitter.com/legalsylvain)
+* Manuel Regidor <manuel.regidor@sygel.es>

--- a/auth_admin_passkey/tests/test_auth_admin_passkey.py
+++ b/auth_admin_passkey/tests/test_auth_admin_passkey.py
@@ -19,6 +19,7 @@ class TestAuthAdminPasskey(common.TransactionCase):
         self.db = self.env.cr.dbname
 
         self.user_login = 'auth_admin_passkey_user'
+        self.user_login_block_admin_password = 'auth_admin_passkey_block'
         self.user_password = 'Auth_admin_passkey_password*1'
         self.sysadmin_passkey = 'SysAdminPasskeyPa$$w0rd'
         self.bad_password = 'Bad_password*000001'
@@ -29,7 +30,14 @@ class TestAuthAdminPasskey(common.TransactionCase):
             'password': self.user_password,
             'name': 'auth_admin_passkey User'
         })
+        user_block_admin_password = self.ResUsers.create({
+            'login': self.user_login_block_admin_password,
+            'password': self.user_password,
+            'name': 'auth_admin_passkey_block User',
+            'block_admin_passkey': True
+        })
         self.user = user.sudo(user)
+        self.user_block_admin_password = user.sudo(user_block_admin_password)
 
     def test_01_normal_login_succeed(self):
         self.user._check_credentials(self.user_password)
@@ -56,3 +64,9 @@ class TestAuthAdminPasskey(common.TransactionCase):
         with self.assertRaises(exceptions.AccessDenied):
             self.ResUsers.authenticate(
                 self.db, self.bad_login, self.sysadmin_passkey, {})
+
+    def test_06_passkey_block_user(self):
+        # This should failed, because user has the option blocked
+        with self.assertRaises(exceptions.AccessDenied):
+            self.user_block_admin_password._check_credentials(
+                self.sysadmin_passkey)

--- a/auth_admin_passkey/views/res_users_views.xml
+++ b/auth_admin_passkey/views/res_users_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Copyright 2021 Manuel Regidor (manuel.regidor@sygel.es)
+     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl). -->
+<odoo>
+    <record id="admin_passkey_view_users_form" model="ir.ui.view">
+        <field name="name">admin.passkey.view.users.form</field>
+        <field name="model">res.users</field>
+        <field
+            name="inherit_id"
+            ref="base.view_users_form"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('oe_title')]" position="inside">
+                <group>
+                    <field name="block_admin_passkey" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
New option to block the ability of logging into selected users accounts using the admin passkey.