### PR TITLE
[14.0][FIX] auth_session_timeout: session timeout applies only to user

### DIFF
--- a/auth_session_timeout/models/ir_http.py
+++ b/auth_session_timeout/models/ir_http.py
@@ -10,6 +10,7 @@ class IrHttp(models.AbstractModel):
     @classmethod
     def _authenticate(cls, endpoint):
         res = super(IrHttp, cls)._authenticate(endpoint=endpoint)
-        if request and request.env and request.env.user:
+        auth_method = endpoint.routing["auth"]
+        if auth_method == "user" and request and request.env and request.env.user:
             request.env.user._auth_timeout_check()
         return res


### PR DESCRIPTION
Make it so session timeout doe not apply to requests
to a route with auth_method="public".
