### PR TITLE
[13.0][FIX] auth_session_timeout - endless redirection loop when cookies are disabled

### DIFF
--- a/auth_session_timeout/models/res_users.py
+++ b/auth_session_timeout/models/res_users.py
@@ -71,6 +71,10 @@ class ResUsers(models.Model):
             try:
 
                 expired = getmtime(path) < deadline
+            except FileNotFoundError:
+                _logger.exception("Exception reading session file modified time.")
+                # Abort timeout check in case session file does not exists
+                return
             except OSError:
                 _logger.exception("Exception reading session file modified time.",)
                 # Force expire the session. Will be resolved with new session.

--- a/auth_session_timeout/readme/CONTRIBUTORS.rst
+++ b/auth_session_timeout/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
 * Jesse Morgan <jmorgan.nz@gmail.com>
 * Dave Lasley <dave@laslabs.com>
 * Nadia Afakrouch <nadia.afa@gmail.com>
+* Petar Najman <petar.najman@modoolar.com>


### PR DESCRIPTION
Hi guys,

We've just had this problem on the SH platform.
When cookies are disabled on client browser Odoo goes into endless redirection loop.

This simple PR resolves that issue.

You can try this by simply runing following command in you terminal: `curl -I <ODOO-URL>` 

Kind Regards,
Petar