### PR TITLE
[12.0][IMP] Add a default Key to the API Key model

### DIFF
--- a/auth_api_key/models/auth_api_key.py
+++ b/auth_api_key/models/auth_api_key.py
@@ -20,7 +20,7 @@ class AuthApiKey(models.Model):
     name = fields.Char(required=True)
     key = fields.Char(
         required=True,
-        default=_default_key,
+        default=lambda self: self._default_key(),
         help="""The API key. Keep the default value in this field if it is
         obtained from the server environment configuration.""",
     )

--- a/auth_api_key/models/auth_api_key.py
+++ b/auth_api_key/models/auth_api_key.py
@@ -1,5 +1,6 @@
 # Copyright 2018 ACSONE SA/NV
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+import uuid
 
 from odoo import api, fields, models, tools, _
 
@@ -13,10 +14,14 @@ class AuthApiKey(models.Model):
     _inherit = "server.env.mixin"
     _description = "API Key"
 
+    def _default_key(self):
+        return uuid.uuid4()
+
     name = fields.Char(required=True)
     key = fields.Char(
         required=True,
-        help="""The API key. Enter a dummy value in this field if it is
+        default=_default_key,
+        help="""The API key. Keep the default value in this field if it is
         obtained from the server environment configuration.""",
     )
     user_id = fields.Many2one(

--- a/auth_api_key/tests/test_auth_api_key.py
+++ b/auth_api_key/tests/test_auth_api_key.py
@@ -65,3 +65,9 @@ class TestAuthApiKey(SavepointCase):
         )
         with self.assertRaises(ValidationError):
             self.env["auth.api.key"]._retrieve_uid_from_api_key("api_key")
+
+    def test_default_key_value(self):
+        api_key = self.AuthApiKey.create(
+            {"name": "Default value", "user_id": self.demo_user.id}
+        )
+        self.assertTrue(bool(api_key.key))


### PR DESCRIPTION
This MR generates a random UUID4 value as a key for new API Key instances.
The value is generated with the  uuid4 random generator of UUID package:

https://docs.python.org/3.8/library/uuid.html#uuid.uuid4

Code moved from 'easy_my_coop_api' module of the repository 'coopiteasy/vertical-cooperative':

https://github.com/coopiteasy/vertical-cooperative/blob/12.0/easy_my_coop_api/models/auth_api_key.py#L20

We propose to move this default value to the main `auth_api_key` module instead of having it in`easy_my_coop_api` because we think that this feature can help every user of this module.