### PR TITLE
[14.0][IMP] auth_api_key: Allow to search on every key even if void

### DIFF
--- a/auth_api_key/models/auth_api_key.py
+++ b/auth_api_key/models/auth_api_key.py
@@ -57,7 +57,7 @@ class AuthApiKey(models.Model):
         if not self.env.user.has_group("base.group_system"):
             raise AccessError(_("User is not allowed"))
         for api_key in self.search([]):
-            if consteq(key, api_key.key):
+            if api_key.key and consteq(key, api_key.key):
                 return api_key.id
         raise ValidationError(_("The key %s is not allowed") % key)
 


### PR DESCRIPTION
If api_key.key is void (due to server_environment config - e.g.: test),
don't raise and break the loop.