### PR TITLE
[14.0] Add auth_api_key_group

### DIFF
--- a/auth_api_key_group/README.rst
+++ b/auth_api_key_group/README.rst
@@ -1,0 +1,1 @@
+wait for the bot ;)

--- a/auth_api_key_group/__init__.py
+++ b/auth_api_key_group/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/auth_api_key_group/__manifest__.py
+++ b/auth_api_key_group/__manifest__.py
@@ -1,0 +1,25 @@
+# Copyright 2021 Camptcamp SA
+# @author: Simone Orsi <simone.orsi@camptocamp.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+{
+    "name": "Auth API key group",
+    "summary": """
+Allow grouping API keys together.
+
+Grouping per se does nothing. This feature is supposed to be used by other modules
+to limit access to services or records based on groups of keys.
+    """,
+    "version": "14.0.1.0.0",
+    "development_status": "Alpha",
+    "license": "LGPL-3",
+    "website": "https://github.com/OCA/server-auth",
+    "author": "Camptcamp,Odoo Community Association (OCA)",
+    "maintainers": ["simahawk"],
+    "depends": ["auth_api_key"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/auth_api_key_view.xml",
+        "views/auth_api_key_group_view.xml",
+    ],
+}

--- a/auth_api_key_group/models/__init__.py
+++ b/auth_api_key_group/models/__init__.py
@@ -1,0 +1,2 @@
+from . import auth_api_key
+from . import auth_api_key_group

--- a/auth_api_key_group/models/auth_api_key.py
+++ b/auth_api_key_group/models/auth_api_key.py
@@ -1,0 +1,19 @@
+# Copyright 2021 Camptcamp SA
+# @author: Simone Orsi <simone.orsi@camptocamp.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+
+from odoo import fields, models
+
+
+class AuthApiKey(models.Model):
+
+    _inherit = "auth.api.key"
+
+    auth_api_key_group_ids = fields.Many2many(
+        comodel_name="auth.api.key.group",
+        relation="auth_api_key_group_rel",
+        column1="key_id",
+        column2="group_id",
+        string="Auth Groups",
+    )

--- a/auth_api_key_group/models/auth_api_key_group.py
+++ b/auth_api_key_group/models/auth_api_key_group.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Camptcamp SA
+# @author: Simone Orsi <simone.orsi@camptocamp.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+
+from odoo import fields, models
+
+
+class AuthApiKeyGroup(models.Model):
+    """Group API keys together."""
+
+    _name = "auth.api.key.group"
+    _description = "API Key auth group"
+
+    name = fields.Char(required=True)
+    code = fields.Char(required=True)
+    auth_api_key_ids = fields.Many2many(
+        comodel_name="auth.api.key",
+        relation="auth_api_key_group_rel",
+        column1="group_id",
+        column2="key_id",
+        string="API Keys",
+    )

--- a/auth_api_key_group/readme/CONTRIBUTORS.rst
+++ b/auth_api_key_group/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Simone Orsi <simone.orsi@camptocamp.com>

--- a/auth_api_key_group/readme/DESCRIPTION.rst
+++ b/auth_api_key_group/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+Allow grouping API keys together.
+
+Grouping per se does nothing. This feature is supposed to be used by other modules
+to limit access to services or records based on groups of keys.

--- a/auth_api_key_group/security/ir.model.access.csv
+++ b/auth_api_key_group/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_auth_api_key_group,access_auth_api_key_group,model_auth_api_key_group,base.group_system,1,1,1,1

--- a/auth_api_key_group/tests/__init__.py
+++ b/auth_api_key_group/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_auth_api_key_group

--- a/auth_api_key_group/tests/test_auth_api_key_group.py
+++ b/auth_api_key_group/tests/test_auth_api_key_group.py
@@ -1,0 +1,46 @@
+# Copyright 2021 Camptcamp SA
+# @author: Simone Orsi <simone.orsi@camptocamp.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+
+from odoo.tests.common import SavepointCase
+
+
+class TestAuthApiKey(SavepointCase):
+    @classmethod
+    def setUpClass(cls, *args, **kwargs):
+        super().setUpClass(*args, **kwargs)
+        cls.AuthApiKey = cls.env["auth.api.key"]
+        cls.AuthApiKeyGroup = cls.env["auth.api.key.group"]
+        cls.demo_user = cls.env.ref("base.user_demo")
+        cls.api_key1 = cls.AuthApiKey.create(
+            {"name": "One", "user_id": cls.demo_user.id, "key": "one"}
+        )
+        cls.api_key2 = cls.AuthApiKey.create(
+            {"name": "Two", "user_id": cls.demo_user.id, "key": "two"}
+        )
+        cls.api_key3 = cls.AuthApiKey.create(
+            {"name": "Three", "user_id": cls.demo_user.id, "key": "three"}
+        )
+        cls.api_key_group1 = cls.AuthApiKeyGroup.create(
+            {
+                "name": "G One",
+                "code": "g-one",
+                "auth_api_key_ids": [(6, 0, (cls.api_key1 + cls.api_key2).ids)],
+            }
+        )
+        cls.api_key_group2 = cls.AuthApiKeyGroup.create(
+            {
+                "name": "G Two",
+                "code": "g-two",
+                "auth_api_key_ids": [(6, 0, cls.api_key3.ids)],
+            }
+        )
+
+    def test_relations(self):
+        self.assertIn(self.api_key_group1, self.api_key1.auth_api_key_group_ids)
+        self.assertIn(self.api_key_group1, self.api_key2.auth_api_key_group_ids)
+        self.assertNotIn(self.api_key_group1, self.api_key3.auth_api_key_group_ids)
+        self.assertIn(self.api_key_group2, self.api_key3.auth_api_key_group_ids)
+        self.assertNotIn(self.api_key_group2, self.api_key1.auth_api_key_group_ids)
+        self.assertNotIn(self.api_key_group2, self.api_key1.auth_api_key_group_ids)

--- a/auth_api_key_group/views/auth_api_key_group_view.xml
+++ b/auth_api_key_group/views/auth_api_key_group_view.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record model="ir.ui.view" id="auth_api_key_group_form_view">
+        <field name="name">auth.api.key.group.form (in auth_api_key_group)</field>
+        <field name="model">auth.api.key.group</field>
+        <field name="arch" type="xml">
+            <form create="false" edit="false">
+                <sheet>
+                    <label for="name" class="oe_edit_only" />
+                    <h1>
+                        <field name="name" class="oe_inline" />
+                    </h1>
+                    <group name="config" colspan="4" col="4">
+                        <field name="code" colspan="4" />
+                        <field name="auth_api_key_ids" colspan="4" />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record model="ir.ui.view" id="auth_api_key_group_tree_view">
+        <field name="name">auth.api.key.group.tree (in auth_api_key_group)</field>
+        <field name="model">auth.api.key.group</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name" />
+                <field name="code" />
+            </tree>
+        </field>
+    </record>
+    <record model="ir.actions.act_window" id="auth_api_key_group_act_window">
+        <field name="name">Auth Api Key Groups</field>
+        <field name="res_model">auth.api.key.group</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[]</field>
+        <field name="context">{}</field>
+    </record>
+    <record model="ir.ui.menu" id="auth_api_key_group_menu">
+        <field name="name">Auth Api Key Groups</field>
+        <field name="parent_id" ref="base.menu_custom" />
+        <field name="action" ref="auth_api_key_group_act_window" />
+        <field name="sequence" eval="100" />
+    </record>
+</odoo>

--- a/auth_api_key_group/views/auth_api_key_view.xml
+++ b/auth_api_key_group/views/auth_api_key_view.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record model="ir.ui.view" id="auth_api_key_form_view">
+        <field name="model">auth.api.key</field>
+        <field name="inherit_id" ref="auth_api_key.auth_api_key_form_view" />
+        <field name="arch" type="xml">
+            <group name="config" position="inside">
+                <field name="auth_api_key_group_ids" colspan="4" />
+            </group>
+        </field>
+    </record>
+</odoo>

--- a/setup/auth_api_key_group/odoo/addons/auth_api_key_group
+++ b/setup/auth_api_key_group/odoo/addons/auth_api_key_group
@@ -1,0 +1,1 @@
+../../../../auth_api_key_group

--- a/setup/auth_api_key_group/setup.py
+++ b/setup/auth_api_key_group/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Allow grouping API keys together.
Grouping per se does nothing. This feature is supposed to be used by other modules
to limit access to services or records based on groups of keys.

CC @gurneyalex 