### PR TITLE
[PORT] PR 294 to 13.0 - auth_jwt: add public_or_jwt auth method

### DIFF
--- a/auth_jwt/models/auth_jwt_validator.py
+++ b/auth_jwt/models/auth_jwt_validator.py
@@ -180,12 +180,20 @@ class AuthJwtValidator(models.Model):
                 f"_auth_method_jwt_{rec.name}",
                 partial(IrHttp.__class__._auth_method_jwt, validator_name=rec.name),
             )
+            setattr(
+                IrHttp.__class__,
+                f"_auth_method_public_or_jwt_{rec.name}",
+                partial(
+                    IrHttp.__class__._auth_method_public_or_jwt, validator_name=rec.name
+                ),
+            )
 
     def _unregister_auth_method(self):
         IrHttp = self.env["ir.http"]
         for rec in self:
             try:
                 delattr(IrHttp.__class__, f"_auth_method_jwt_{rec.name}")
+                delattr(IrHttp.__class__, f"_auth_method_public_or_jwt_{rec.name}")
             except AttributeError:
                 pass
 

--- a/auth_jwt/readme/USAGE.rst
+++ b/auth_jwt/readme/USAGE.rst
@@ -5,9 +5,9 @@ To use it, you must:
 
 * Create an ``auth.jwt.validator`` record to configure how the JWT token will
   be validated.
-* Add an ``auth="jwt_{validator-name}"`` attribute to the routes
-  you want to protect where ``{validator-name}`` corresponds to the name
-  attribute of the JWT validator record.
+* Add an ``auth="jwt_{validator-name}"`` or ``auth="public_or_jwt_{validator-name}"``
+  attribute to the routes you want to protect where ``{validator-name}`` corresponds to
+  the name attribute of the JWT validator record.
 
 The ``auth_jwt_demo`` module provides examples.
 
@@ -45,3 +45,11 @@ strategies can be provided by overriding the ``_get_partner_id()`` method
 and extending the ``partner_id_strategy`` selection field.
 
 The decoded JWT payload is stored in ``request.jwt_payload``.
+
+The ``public_auth_jwt`` method delegates authentication to the standard Odoo ``public``
+method when the Authorization header is not set. If it is set, the regular JWT
+authentication is performed as described above. This method is useful for public
+endpoints that need to work for anonymous users, but can be enhanced when an
+authenticated user is know. A typical use case is a "add to cart" endpoint that can work
+for anonymous users, but can be enhanced by binding the cart to a known customer when
+the authenticated user is known.

--- a/auth_jwt_demo/controllers/main.py
+++ b/auth_jwt_demo/controllers/main.py
@@ -43,3 +43,27 @@ class JWTTestController(Controller):
             partner = request.env["res.partner"].browse(request.jwt_partner_id)
             data.update(name=partner.name, email=partner.email)
         return Response(json.dumps(data), content_type="application/json", status=200)
+
+    @route(
+        "/auth_jwt_demo/keycloak/whoami-public-or-jwt",
+        type="http",
+        auth="public_or_jwt_demo_keycloak",
+        csrf=False,
+        cors="*",
+        save_session=False,
+        methods=["GET", "OPTIONS"],
+    )
+    def whoami_public_or_keycloak(self):
+        """To use with the demo_keycloak validator.
+
+        You can play with this using the browser app in tests/spa and the
+        identity provider in tests/keycloak.
+        """
+        data = {}
+        if hasattr(request, "jwt_partner_id") and request.jwt_partner_id:
+            partner = request.env["res.partner"].browse(request.jwt_partner_id)
+            data.update(name=partner.name, email=partner.email)
+        else:
+            # public
+            data.update(name="Anonymous")
+        return Response(json.dumps(data), content_type="application/json", status=200)

--- a/auth_jwt_demo/tests/spa/index.html
+++ b/auth_jwt_demo/tests/spa/index.html
@@ -11,13 +11,17 @@
     <button id="btn-login" disabled>Log in</button>
     <button id="btn-logout" disabled>Log out</button>
     <button id="btn-whoami">Who am I? (api call)</button>
+    <button id="btn-whoami-public-or-jwt">Who am I (public or auth)? (api call)</button>
     <script type="module">
-      import {onload, login, logout, whoami} from "./js/app.js";
+      import {onload, login, logout, whoami, whoami_public_or_jwt} from "./js/app.js";
 
       window.onload = onload;
       document.getElementById("btn-login").onclick = login;
       document.getElementById("btn-logout").onclick = logout;
       document.getElementById("btn-whoami").onclick = whoami;
+      document.getElementById(
+        "btn-whoami-public-or-jwt"
+      ).onclick = whoami_public_or_jwt;
     </script>
   </body>
 </html>

--- a/auth_jwt_demo/tests/spa/js/app.js
+++ b/auth_jwt_demo/tests/spa/js/app.js
@@ -76,11 +76,11 @@ async function refresh() {
     client.startSilentRenew();
 }
 
-async function whoami() {
+async function _whoami(endpoint) {
     let user = await client.getUser();
     try {
         let response = await fetch(
-            "http://localhost:8069/auth_jwt_demo/keycloak/whoami",
+            "http://localhost:8069/auth_jwt_demo/keycloak" + endpoint,
             {
                 headers: {
                     ...(user && {Authorization: `Bearer ${user.access_token}`}),
@@ -94,4 +94,12 @@ async function whoami() {
     }
 }
 
-export {onload, login, logout, whoami};
+async function whoami() {
+    await _whoami("/whoami");
+}
+
+async function whoami_public_or_jwt() {
+    await _whoami("/whoami-public-or-jwt");
+}
+
+export {onload, login, logout, whoami, whoami_public_or_jwt};


### PR DESCRIPTION
This method is useful for public endpoints that need
to work for anonymous user, but can be enhanced when
an authenticated user is know.

A typical use case is a "add to cart" enpoint that can
work for anonymous users, but can be enhanced by
binding the cart to a known customer when the authenticated
user is known.