### PR TITLE
[12.0][FIX] password_security: Allow translations in password constraints

### DIFF
--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -115,7 +115,7 @@ class ResUsers(models.Model):
         if company_id.password_special:
             message.append(
                 _(
-                    "\n* Special character (at least % characters)"
+                    "\n* Special character (at least %s characters)"
                     % str(company_id.password_special)
                 )
             )

--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -99,7 +99,8 @@ class ResUsers(models.Model):
             value = int(value)
             if value > 0:
                 at_least_msg = bracket_singular if value <= 1 else bracket_plural
-                message = f"* {constraint_type} {at_least_msg % value}"
+                at_least_msg %= value
+                message = "* " + constraint_type + " " + at_least_msg
                 messages.append(message)
 
         add_message(company_id.password_lower, _("Lowercase letter"))

--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -92,24 +92,41 @@ class ResUsers(models.Model):
         company_id = self.company_id
         message = []
         if company_id.password_lower:
-            message.append('\n* ' + 'Lowercase letter (At least ' + str(
-                company_id.password_lower) + ' character)')
+            message.append(
+                _(
+                    "\n* Lowercase letter (at least %s characters)"
+                    % str(company_id.password_lower)
+                )
+            )
         if company_id.password_upper:
-            message.append('\n* ' + 'Uppercase letter (At least ' + str(
-                company_id.password_upper) + ' character)')
+            message.append(
+                _(
+                    "\n* Uppercase letter (at least %s characters)"
+                    % str(company_id.password_upper)
+                )
+            )
         if company_id.password_numeric:
-            message.append('\n* ' + 'Numeric digit (At least ' + str(
-                company_id.password_numeric) + ' character)')
+            message.append(
+                _(
+                    "\n* Numeric digit (at least %s characters)"
+                    % str(company_id.password_numeric)
+                )
+            )
         if company_id.password_special:
-            message.append('\n* ' + 'Special character (At least ' + str(
-                company_id.password_special) + ' character)')
+            message.append(
+                _(
+                    "\n* Special character (at least % characters)"
+                    % str(company_id.password_special)
+                )
+            )
         if message:
-            message = [_('Must contain the following:')] + message
+            message = [_("Must contain the following:")] + message
         if company_id.password_length:
-            message = ['Password must be %d characters or more.' %
-                       company_id.password_length
-                       ] + message
-        return '\r'.join(message)
+            message = [
+                _("Password must be %d characters or more.")
+                % company_id.password_length
+            ] + message
+        return "\r".join(message)
 
     @api.multi
     def _check_password(self, password):


### PR DESCRIPTION
I've just committed the changed made to password_match_message from OCA/server-auth/14.0, which allows translations

https://github.com/OCA/server-auth/blame/14.0/password_security/models/res_users.py#L84

Please don't take into account the title of the commit.
It's the convention that we use @CompassionCH for our ticketing system.