### PR TITLE
[14.0][FIX] password_security: 2FA workflow not being considered properly

### DIFF
--- a/password_security/__manifest__.py
+++ b/password_security/__manifest__.py
@@ -16,6 +16,7 @@
     "depends": [
         "auth_signup",
         "auth_password_policy_signup",
+        "auth_totp",
     ],
     "website": "https://github.com/OCA/server-auth",
     "external_dependencies": {

--- a/password_security/controllers/__init__.py
+++ b/password_security/controllers/__init__.py
@@ -2,3 +2,4 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from . import main
+from . import home

--- a/password_security/controllers/home.py
+++ b/password_security/controllers/home.py
@@ -1,0 +1,25 @@
+# Copyright 2022 brain-tec AG (https://bt-group.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import http
+from odoo.http import request
+
+from odoo.addons.auth_totp.controllers.home import Home
+
+
+class PasswordSecurity2FAHome(Home):
+    @http.route()
+    def web_totp(self, redirect=None, **kwargs):
+        already_logged_in = request.session.uid
+        result = super(PasswordSecurity2FAHome, self).web_totp(redirect, **kwargs)
+
+        if already_logged_in or not (
+            request.session.uid and request.env.user._password_has_expired()
+        ):
+            return result
+
+        # My password is expired, kick me out
+        request.env.user.action_expire_password()
+        request.session.logout(keep_db=True)
+        redirect = request.env.user.partner_id.signup_url
+        return http.redirect_with_hash(redirect)

--- a/password_security/controllers/main.py
+++ b/password_security/controllers/main.py
@@ -40,7 +40,8 @@ class PasswordSecurityHome(AuthSignupHome):
         if not request.params.get("login_success"):
             return response
         # Now, I'm an authenticated user
-        if not request.env.user._password_has_expired():
+        # With 2FA there is a second step and we would not be completely logged in
+        if not (request.session.uid and request.env.user._password_has_expired()):
             return response
         # My password is expired, kick me out
         request.env.user.action_expire_password()

--- a/password_security/readme/CONTRIBUTORS.rst
+++ b/password_security/readme/CONTRIBUTORS.rst
@@ -4,6 +4,7 @@
 * Petar Najman <petar.najman@modoolar.com>
 * Shepilov Vladislav <shepilov.v@protonmail.com>
 * Florian Kantelberg <florian.kantelberg@initos.com>
+* Carlos Jimeno <carlos.jimeno@bt-group.com>
 
 * `Open Source Integrators <https://opensourceintegrators.com>`_
 

--- a/password_security/tests/__init__.py
+++ b/password_security/tests/__init__.py
@@ -5,4 +5,5 @@ from . import (
     test_password_security_home,
     test_password_security_session,
     test_res_users,
+    test_totp,
 )

--- a/password_security/tests/test_totp.py
+++ b/password_security/tests/test_totp.py
@@ -1,0 +1,26 @@
+# Copyright 2022 Braintec AG
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo.tests import tagged, HttpCase
+from datetime import datetime, timedelta
+@tagged('post_install', '-at_install')
+class TestTOTP(HttpCase):
+
+    def test_totp(self):
+        # 1. Login with demo user
+        uid = self.env.ref('base.user_demo').id
+        self.assertEqual(uid, self.env.ref('base.user_demo').id)
+
+        # 2. Check that we are logged in
+        self.authenticate(user="demo", password="demo")
+        self.assertEqual(self.session.uid, uid)
+
+        # 3. Check expired password
+        self.assertEqual(self.env.user._password_has_expired(), False)
+        self.env.user.action_expire_password()
+        date_tomorrow = datetime.now() + timedelta(days=1)
+        self.assertEqual(self.env.user.partner_id.signup_expiration.strftime('%m/%d/%Y %H:%M:%S'),
+                         date_tomorrow.strftime('%m/%d/%Y %H:%M:%S'))
+
+        self.logout()
+        self.assertNotEqual(self.session.uid, uid)

--- a/password_security/tests/test_totp.py
+++ b/password_security/tests/test_totp.py
@@ -1,15 +1,17 @@
 # Copyright 2022 Braintec AG
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
-from odoo.tests import tagged, HttpCase
 from datetime import datetime, timedelta
-@tagged('post_install', '-at_install')
-class TestTOTP(HttpCase):
 
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestTOTP(HttpCase):
     def test_totp(self):
         # 1. Login with demo user
-        uid = self.env.ref('base.user_demo').id
-        self.assertEqual(uid, self.env.ref('base.user_demo').id)
+        uid = self.env.ref("base.user_demo").id
+        self.assertEqual(uid, self.env.ref("base.user_demo").id)
 
         # 2. Check that we are logged in
         self.authenticate(user="demo", password="demo")
@@ -19,8 +21,10 @@ class TestTOTP(HttpCase):
         self.assertEqual(self.env.user._password_has_expired(), False)
         self.env.user.action_expire_password()
         date_tomorrow = datetime.now() + timedelta(days=1)
-        self.assertEqual(self.env.user.partner_id.signup_expiration.strftime('%m/%d/%Y %H:%M:%S'),
-                         date_tomorrow.strftime('%m/%d/%Y %H:%M:%S'))
+        self.assertEqual(
+            self.env.user.partner_id.signup_expiration.strftime("%m/%d/%Y %H:%M:%S"),
+            date_tomorrow.strftime("%m/%d/%Y %H:%M:%S"),
+        )
 
         self.logout()
         self.assertNotEqual(self.session.uid, uid)


### PR DESCRIPTION
When a user with 2FA enabled tried to log in, the user whose password expiration was being checked
was not the actual user logging in, instead it was OdooBot. Some changes were introduced to have
the 2fa module (auth_totp) into account.

Fixes #333 