### PR TITLE
[IMP] timeout check triggered on session uid

### DIFF
--- a/auth_session_timeout/models/ir_http.py
+++ b/auth_session_timeout/models/ir_http.py
@@ -10,6 +10,6 @@ class IrHttp(models.AbstractModel):
     @classmethod
     def _authenticate(cls, auth_method='user'):
         res = super(IrHttp, cls)._authenticate(auth_method=auth_method)
-        if request and request.env and request.env.user:
+        if request and request.session and request.session.uid:
             request.env.user._auth_timeout_check()
         return res


### PR DESCRIPTION
Triggering timeout check on request session.uid, because env.user may be null.

env,user._auth_timeout_check  will work with an empty recordset ( it is @api.model_cr_context)