### PR TITLE
[14.0] [IMP] auth_jwt: Add validator.next_validator_id to allow validator chaining

### DIFF
--- a/auth_jwt/exceptions.py
+++ b/auth_jwt/exceptions.py
@@ -30,3 +30,17 @@ class UnauthorizedInvalidToken(Unauthorized):
 
 class UnauthorizedPartnerNotFound(Unauthorized):
     pass
+
+
+class CompositeJwtError(Unauthorized):
+    """Indicate that multiple errors occurred during JWT chain validation."""
+
+    def __init__(self, errors):
+        self.errors = errors
+        super().__init__(
+            "Multiple errors occurred during JWT chain validation:\n"
+            + "\n".join(
+                "{}: {}".format(validator_name, error)
+                for validator_name, error in self.errors.items()
+            )
+        )

--- a/auth_jwt/views/auth_jwt_validator_views.xml
+++ b/auth_jwt/views/auth_jwt_validator_views.xml
@@ -10,6 +10,7 @@
                         <group colspan="2">
                             <field name="name" />
                             <field name="audience" />
+                            <field name="next_validator_id" />
                         </group>
                         <group colspan="2">
                             <field name="issuer" />
@@ -69,6 +70,7 @@
                 <field name="user_id_strategy" />
                 <field name="partner_id_strategy" />
                 <field name="partner_id_required" />
+                <field name="next_validator_id" />
             </tree>
         </field>
     </record>


### PR DESCRIPTION
This PR adds `next_validator_id` field to `auth.jwt.validator` to allow multiple jwt validators to be checked in chain.

This PR also removes the cursor creation for the validator execution since it prevents to implement for instance an auto create partner strategy being on a different transaction. (It also remove the now useless validator patch in tests).