### PR TITLE
[14.0] [IMP] auth_jwt: Add email_create partner strategy

### DIFF
--- a/auth_jwt/__manifest__.py
+++ b/auth_jwt/__manifest__.py
@@ -12,6 +12,10 @@
     "website": "https://github.com/OCA/server-auth",
     "depends": [],
     "external_dependencies": {"python": ["pyjwt", "cryptography"]},
-    "data": ["security/ir.model.access.csv", "views/auth_jwt_validator_views.xml"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/auth_jwt_validator_views.xml",
+        "views/res_partner_views.xml",
+    ],
     "demo": [],
 }

--- a/auth_jwt/models/__init__.py
+++ b/auth_jwt/models/__init__.py
@@ -1,2 +1,3 @@
 from . import auth_jwt_validator
 from . import ir_http
+from . import res_partner

--- a/auth_jwt/models/res_partner.py
+++ b/auth_jwt/models/res_partner.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    created_by_jwt = fields.Boolean("Created by JWT", default=False)
+    auth_jwt_email = fields.Char("Auth JWT Email")

--- a/auth_jwt/views/res_partner_views.xml
+++ b/auth_jwt/views/res_partner_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="name">res.partner.form</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <field name="website" position="before">
+                <field
+                    name="auth_jwt_email"
+                    widget="email"
+                    groups="base.group_no_one"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This new strategy will automatically create unknown partners.
The automatically created partners will have a `created_by_jwt` flag set to True.
All partners will now have a `auth_jwt_email` set at first auth link which can be different from partner email, similar to how core `auth_oauth` addon handles oauth uid.