### PR TITLE
[FIX][13.0]auth_saml: Raise error if password change is not allowed

### DIFF
--- a/auth_saml/tests/test_pysaml.py
+++ b/auth_saml/tests/test_pysaml.py
@@ -1,7 +1,7 @@
 import base64
 import os
 
-from odoo.exceptions import AccessDenied
+from odoo.exceptions import AccessDenied, ValidationError
 from odoo.tests import HttpCase, tagged
 
 from .fake_idp import FakeIDP
@@ -11,7 +11,9 @@ from .fake_idp import FakeIDP
 class TestPySaml(HttpCase):
     def setUp(self):
         super().setUp()
-
+        self.env["ir.config_parameter"].set_param(
+            "auth_saml.allow_saml_uid_and_internal_password", False
+        )
         sp_pem_public = None
         sp_pem_private = None
 
@@ -75,6 +77,7 @@ class TestPySaml(HttpCase):
 
         # Standard login using password
         self.authenticate(user="test@example.com", password="Lu,ums-7vRU>0i]=YDLa")
+
         self.assertEqual(self.session.uid, user.id)
 
         self.logout()
@@ -123,6 +126,9 @@ class TestPySaml(HttpCase):
                 ]
             }
         )
+
+        with self.assertRaises(ValidationError):
+            user.password = "test_change_password"
 
         redirect_url = self.saml_provider._get_auth_request()
         self.assertIn("http://localhost:8000/sso/redirect?SAMLRequest=", redirect_url)


### PR DESCRIPTION
Impacted versions: 13.0

Steps to reproduce:
 Go to settings >Integrations > Allow SAML users to possess an Odoo password (warning: decreases security) > False
 Go to settings > user (only those records that are associated with SAML)> action > change password (restricts the user to change the password if the user have a SAML provider)

Current behaviour: In settings, there is a boolean field("Allow SAML users to possess an Odoo password (warning: decreases security)").
Go to the user(only those records that are associated with SAML) and change the password. While changing the password of that user, it doesn't give any warning considering that the above boolean field is set to be False.

Expected behaviour: While changing a password of the user, it should raise a ValidationError("This database disallows users to have both passwords and SAML IDs. Error for logins $user"), if the user has any SAML provider/s and boolean field set to be True (which is located at Settings > Integrations)

Fix has been inspired by #342 