### PR TITLE
[IMP][12.0] auth_oidc: allow assign groups from token claims

### DIFF
--- a/auth_oidc/__manifest__.py
+++ b/auth_oidc/__manifest__.py
@@ -16,6 +16,9 @@
     "summary": "Allow users to login through OpenID Connect Provider",
     "external_dependencies": {"python": ["jose"]},
     "depends": ["auth_oauth"],
-    "data": ["views/auth_oauth_provider.xml"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/auth_oauth_provider.xml",
+    ],
     "demo": ["demo/local_keycloak.xml"],
 }

--- a/auth_oidc/demo/local_keycloak.xml
+++ b/auth_oidc/demo/local_keycloak.xml
@@ -17,4 +17,9 @@
             name="jwks_uri"
         >http://localhost:8080/auth/realms/master/protocol/openid-connect/certs</field>
     </record>
+    <record id="local_keycloak_group_line" model="auth.oauth.provider.group_line">
+        <field name="provider_id" ref="local_keycloak" />
+        <field name="group_id" ref="base.group_no_one" />
+        <field name="expression">token['name'] == 'test'</field>
+    </record>
 </odoo>

--- a/auth_oidc/models/auth_oauth_provider.py
+++ b/auth_oidc/models/auth_oauth_provider.py
@@ -105,8 +105,12 @@ class AuthOauthProviderGroupLine(models.Model):
         self.ensure_one()
 
         class Defaultdict2(collections.defaultdict):
+            """Class keeping yielding defaultdicts"""
             def __init__(self, *args, **kwargs):
                 super().__init__(Defaultdict2, *args, **kwargs)
+
+            def __eq__(self, other):
+                return False
 
         return tools.safe_eval(
             self.expression, {

--- a/auth_oidc/models/auth_oauth_provider.py
+++ b/auth_oidc/models/auth_oauth_provider.py
@@ -2,12 +2,13 @@
 # Copyright 2021 ACSONE SA/NV <https://acsone.eu>
 # License: AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
+import collections
 import logging
 import secrets
 
 import requests
 
-from odoo import fields, models, tools
+from odoo import api, exceptions, fields, models, tools
 
 try:
     from jose import jwt
@@ -45,6 +46,9 @@ class AuthOauthProvider(models.Model):
         string="Token URL", help="Required for OpenID Connect authorization code flow."
     )
     jwks_uri = fields.Char(string="JWKS URL", help="Required for OpenID Connect.")
+    group_line_ids = fields.One2many(
+        "auth.oauth.provider.group_line", "provider_id", string="Group mappings",
+    )
 
     @tools.ormcache("self.jwks_uri", "kid")
     def _get_key(self, kid):
@@ -80,3 +84,33 @@ class AuthOauthProvider(models.Model):
 
         res.update(self._map_token_values(res))
         return res
+
+
+class AuthOauthProviderGroupLine(models.Model):
+    _name = 'auth.oauth.provider.group_line'
+
+    provider_id = fields.Many2one('auth.oauth.provider', required=True)
+    group_id = fields.Many2one('res.groups', required=True)
+    expression = fields.Char(required=True, help="Variables: user, token")
+
+    @api.constrains('expression')
+    def _check_expression(self):
+        for this in self:
+            try:
+                this._eval_expression(self.env.user, {})
+            except (AttributeError, KeyError, NameError) as e:
+                raise exceptions.ValidationError('\n'.join(e.args))
+
+    def _eval_expression(self, user, token):
+        self.ensure_one()
+
+        class Defaultdict2(collections.defaultdict):
+            def __init__(self, *args, **kwargs):
+                super().__init__(Defaultdict2, *args, **kwargs)
+
+        return tools.safe_eval(
+            self.expression, {
+                'user': user,
+                'token': Defaultdict2(token),
+            }
+        )

--- a/auth_oidc/security/ir.model.access.csv
+++ b/auth_oidc/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_auth_oauth_provider_group_line,auth_oauth_provider,model_auth_oauth_provider_group_line,base.group_system,1,1,1,1

--- a/auth_oidc/static/description/index.html
+++ b/auth_oidc/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Authentication OpenID Connect</title>
 <style type="text/css">
 

--- a/auth_oidc/tests/test_auth_oidc_auth_code.py
+++ b/auth_oidc/tests/test_auth_oidc_auth_code.py
@@ -74,6 +74,12 @@ class TestAuthOIDCAuthorizationCodeFlow(common.HttpCase):
             self.assertTrue(params["state"])
             self.assertEqual(params["redirect_uri"], [BASE_URL + "/auth_oauth/signin"])
 
+    def test_group_expression(self):
+        """Test that group expressions evaluate correctly"""
+        group_line = self.env.ref('auth_oidc.local_keycloak').group_line_ids[:1]
+        group_line.expression = 'token["test"]["test"] == 1'
+        self.assertFalse(group_line._eval_expression(self.env.user, {}))
+
     @responses.activate
     def test_login(self):
         """Test that login works"""

--- a/auth_oidc/views/auth_oauth_provider.xml
+++ b/auth_oidc/views/auth_oauth_provider.xml
@@ -19,6 +19,16 @@
                 <field name="token_endpoint" />
                 <field name="jwks_uri" />
             </field>
+            <xpath expr="//sheet/group[last()]" position="after">
+                <group name="mappings">
+                    <field name="group_line_ids">
+                        <tree editable="bottom">
+                            <field name="group_id" />
+                            <field name="expression" />
+                        </tree>
+                    </field>
+                </group>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/auth_oidc/views/auth_oauth_provider.xml
+++ b/auth_oidc/views/auth_oauth_provider.xml
@@ -24,7 +24,7 @@
                     <field name="group_line_ids">
                         <tree editable="bottom">
                             <field name="group_id" />
-                            <field name="expression" />
+                            <field name="expression" placeholder="token['scope']['value'] == 'hello world'" />
                         </tree>
                     </field>
                 </group>


### PR DESCRIPTION
this is the oauth equivalent of [users_ldap_groups](https://github.com/OCA/server-auth/tree/13.0/users_ldap_groups), allowing to also configure all authorizations in your identity provider.