### PR TITLE
[11.0][FIX] auth_session_timeout: prevent infinite redirections

### DIFF
--- a/auth_session_timeout/models/res_users.py
+++ b/auth_session_timeout/models/res_users.py
@@ -60,6 +60,9 @@ class ResUsers(models.Model):
         if not http.request:
             return
 
+        if http.request.httprequest.path in ['/web/login','/web/reset_password']:
+            return
+
         session = http.request.session
 
         # Calculate deadline

--- a/auth_session_timeout/models/res_users.py
+++ b/auth_session_timeout/models/res_users.py
@@ -60,7 +60,7 @@ class ResUsers(models.Model):
         if not http.request:
             return
 
-        if http.request.httprequest.path in ['/web/login','/web/reset_password']:
+        if http.request.httprequest.path in ['/web/login', '/web/reset_password']:
             return
 
         session = http.request.session


### PR DESCRIPTION
Infinite redirections loop has been reported in the auth_session_timeout module.
ex.) [issue-33](https://github.com/OCA/server-auth/issues/33), [issue-80](https://github.com/OCA/server-auth/issues/80) for V11.
and 208, 216 for V12.

Actions to reproduce the issue:
1. Set "inactive_session_time_out_delay" to any short time you like. (We used 15 and 1800)
2. Log in with your own account and leave the session to be logged out by the module.
3. Repeat logging in and being logged out. (three times we did.)
4. Change your device or browser (secret mode browser is also OK.) and log in with the same account.
5. Then you would face to the redirection loop when access to the {domain}/ or {domain}/web/login and so on.
Once redirection starts, everyone seems to face it. 
If you delete the cookie, loop would not happen temporally.

Solution:
as mentioned in issue-33, /web/login and /web/reset_password should be always ignored by checking sessions.

We checked this change is effective in V11.