### PR TITLE
[FIX] auth_session_timeout: `getmtime` always return current time

### DIFF
--- a/auth_session_timeout/tests/test_res_users.py
+++ b/auth_session_timeout/tests/test_res_users.py
@@ -8,11 +8,6 @@ import mock
 
 from odoo.http import SessionExpiredException
 from odoo.tests.common import TransactionCase
-from odoo.tools.misc import mute_logger
-
-
-class EndTestException(Exception):
-    """It stops tests from continuing"""
 
 
 class TestResUsers(TransactionCase):
@@ -39,9 +34,6 @@ class TestResUsers(TransactionCase):
         self.db = mock.MagicMock()
         self.uid = mock.MagicMock()
         self.passwd = mock.MagicMock()
-        self.path = "/this/is/a/test/path"
-        get_filename = http_mock.root.session_store.get_session_filename
-        get_filename.return_value = self.path
         return self.ResUsers._auth_timeout_check()
 
     def test_session_validity_no_request(self):
@@ -51,60 +43,20 @@ class TestResUsers(TransactionCase):
             res = self._auth_timeout_check(assets["http"])
             self.assertFalse(res)
 
-    def test_session_validity_gets_session_file(self):
+    def test_session_validity_gets_session(self):
         """It should call get the session file for the session id"""
         with self._mock_assets() as assets:
-            get_params = assets["http"].request.env[""].get_session_parameters
-            get_params.return_value = 0, []
-            store = assets["http"].root.session_store
-            store.get_session_filename.side_effect = EndTestException
-            with self.assertRaises(EndTestException):
-                self._auth_timeout_check(assets["http"])
-            store.get_session_filename.assert_called_once_with(
-                assets["http"].request.session.sid,
-            )
+            session = assets["http"].request.session.get
+            session.return_value = time.time()
+            self._auth_timeout_check(assets["http"])
 
     def test_session_validity_logout(self):
         """It should log out of session if past deadline"""
-        with self._mock_assets(["http", "getmtime", "utime"]) as assets:
-            get_params = assets["http"].request.env[""].get_session_parameters
-            get_params.return_value = -9999, []
-            assets["getmtime"].return_value = 0
+        with self._mock_assets(["http"]) as assets:
+            session = assets["http"].request.session.get
+            session.return_value = time.time() - 10000
             with self.assertRaises(SessionExpiredException):
                 self._auth_timeout_check(assets["http"])
             assets["http"].request.session.logout.assert_called_once_with(
                 keep_db=True,
             )
-
-    def test_session_validity_updates_utime(self):
-        """It should update utime of session file if not expired"""
-        with self._mock_assets(["http", "getmtime", "utime"]) as assets:
-            get_params = assets["http"].request.env[""].get_session_parameters
-            get_params.return_value = 9999, []
-            assets["getmtime"].return_value = time.time()
-            self._auth_timeout_check(assets["http"])
-            assets["utime"].assert_called_once_with(
-                assets["http"].root.session_store.get_session_filename(),
-                None,
-            )
-
-    @mute_logger("odoo.addons.auth_session_timeout.models.res_users")
-    def test_session_validity_os_error_guard(self):
-        """It should properly guard from OSError & return"""
-        with self._mock_assets(["http", "utime", "getmtime"]) as assets:
-            get_params = assets["http"].request.env[""].get_session_parameters
-            get_params.return_value = 0, []
-            assets["getmtime"].side_effect = OSError
-            with self.assertRaises(SessionExpiredException):
-                self._auth_timeout_check(assets["http"])
-
-    def test_on_timeout_session_loggedout(self):
-        with self._mock_assets(["http", "getmtime"]) as assets:
-            assets["getmtime"].return_value = 0
-            assets["http"].request.session.uid = self.env.uid
-            assets["http"].request.session.dbname = self.env.cr.dbname
-            assets["http"].request.session.sid = 123
-            assets["http"].request.session.logout = mock.Mock()
-            with self.assertRaises(SessionExpiredException):
-                self.ResUsers._auth_timeout_check()
-            self.assertTrue(assets["http"].request.session.logout.called)


### PR DESCRIPTION
Fixed: #259
We can't assume that this module is the only one modifying the time of session files. For some reason, on Docker instances of Odoo (that includes Odoo.SH) these session files get modified on each page reload even before `getmtime` in this module is called, which means it never expires.

This solution seems more elegant and common among the whole WWW when it comes to expiring sessions.
It also removes the need for try/exept blocks and the tests that came with them; Removes the need of os imports.