### PR TITLE
[FIX][14.0][vault] Lock out of users when login changed

### DIFF
--- a/vault/__manifest__.py
+++ b/vault/__manifest__.py
@@ -10,7 +10,7 @@
     "application": True,
     "author": "initOS GmbH, Odoo Community Association (OCA)",
     "category": "Vault",
-    "depends": ["web"],
+    "depends": ["base_setup", "web"],
     "data": [
         "security/ir.model.access.csv",
         "security/ir_rule.xml",

--- a/vault/models/res_users.py
+++ b/vault/models/res_users.py
@@ -61,4 +61,5 @@ class ResUsers(models.Model):
             "public": self.active_key.public,
             "salt": self.active_key.salt,
             "uuid": self.active_key.uuid,
+            "version": self.active_key.version,
         }

--- a/vault/readme/DESCRIPTION.rst
+++ b/vault/readme/DESCRIPTION.rst
@@ -3,3 +3,5 @@ This module implements a vault for secrets and files using end-to-end-encryption
 The server can never access the secrets with the information available. Only people registered in the vault can decrypt or encrypt values in a vault. The meta data isn't encrypted to be able to search/filter for entries more easily.
 
 This modules requires a secure context for the browser to work properly.
+
+The `vault-recovery <https://github.com/fkantelberg/vault-recovery>`_ project focuses on disaster recovery in case of an incident to recover secrets from old database backups or old exports.

--- a/vault/tests/test_vault.py
+++ b/vault/tests/test_vault.py
@@ -83,23 +83,26 @@ class TestVault(TransactionCase):
 
         # Raise some errors because of wrong parameters
         with self.assertRaises(ValidationError):
-            model.store(1, "iv", "private", "public", 42)
+            model.store(1, "iv", "private", "public", 42, 42)
 
         with self.assertRaises(ValidationError):
-            model.store(3000, "iv", "private", "public", "salt")
+            model.store(3000, "iv", "private", "public", "salt", 42)
+
+        with self.assertRaises(ValidationError):
+            model.store(4000, "iv", "private", "public", "salt", "abc")
 
         # Actually store a new key
-        uuid = model.store(4000, "iv", "private", "public", "salt")
+        uuid = model.store(4000, "iv", "private", "public", "salt", 42)
         rec = model.search([("uuid", "=", uuid)])
         self.assertEqual(rec.private, "private")
         self.assertTrue(rec.current)
 
         # Don't store the same again
-        uuid = model.store(4000, "iv", "private", "public", "salt")
+        uuid = model.store(4000, "iv", "private", "public", "salt", 42)
         self.assertFalse(uuid)
 
         # Store a new one and disable the old one
-        uuid = model.store(4000, "iv", "more private", "public", "salt")
+        uuid = model.store(4000, "iv", "more private", "public", "salt", 42)
         self.assertFalse(rec.current)
 
         rec = model.search([("uuid", "=", uuid)])


### PR DESCRIPTION
During the work on disaster recovery I discovered a bug regarding the decryption of the private key. Previously the password for encrypting/decrypting the private key was formed from the login of the user and the given password and/or passfile. If the user logjn is changed the first part and therefore the password will always be wrong locking out the user from his private key and all vaults effectivly.

The fix is taking care of it by introducing a versioning to the res.users.key to indicate if a migration of the key is required. The javascript should migrate the private keys with the next usage automatically. The private key will be re-encrypting without the login and stored in the database as a new res.users.key with version 1.

It will only cause a problem if the login already changed. In that case it's recommended to change the login back shortly. Alternativly the res.users.key could be flagged as version 1 and the user should input `<username>|<password>`.