### PR TITLE
[14.0][FIX] oauth_oidc token mapping after upstream change

### DIFF
--- a/auth_oidc/models/auth_oauth_provider.py
+++ b/auth_oidc/models/auth_oauth_provider.py
@@ -60,8 +60,7 @@ class AuthOauthProvider(models.Model):
         if self.token_map:
             for pair in self.token_map.split(" "):
                 from_key, to_key = [k.strip() for k in pair.split(":", 1)]
-                if to_key not in res:
-                    res[to_key] = res.get(from_key, "")
+                res[to_key] = res.get(from_key, "")
         return res
 
     def _parse_id_token(self, id_token, access_token):


### PR DESCRIPTION
Upstream now starts injecting values that don't exist in the OAuth response (see: https://github.com/odoo/odoo/commit/fb3c4845b1549bc2e1378620a5f01e52aa4dbbdb#diff-9928f68e69da2abd2aa17e05de18875e0fea83edc2d55e942c9bbb65776f6937R53-R66), based on guess work.

This interferes with existing installations where a token mapping was being used to provide a user_id mapping.

Unfortunately in the case of Azure Active Directory the user_id upstream now copies across is difficult to find to provision users with since it has no bearing on things like the UPN, etc. that would be considered "more normal" in the AD world (I'm sure it can be found, but it seems difficult).

More over it breaks existing installations where a token mapping was providing a different value.

--

I'm not clear if this is the best way to handle this situation.

If anyone has any better ideas, I'll happily take them for feedback, I just needed a quick fix this morning to allow us into our own Odoo installation.