### PR TITLE
[IMP] auth_session_timeout: ignore public and none routes

### DIFF
--- a/auth_session_timeout/models/ir_http.py
+++ b/auth_session_timeout/models/ir_http.py
@@ -11,5 +11,5 @@ class IrHttp(models.AbstractModel):
     def _authenticate(cls, auth_method='user'):
         res = super(IrHttp, cls)._authenticate(auth_method=auth_method)
         if request and request.env and request.env.user:
-            request.env.user._auth_timeout_check()
+            request.env.user._auth_timeout_check(auth_method)
         return res

--- a/auth_session_timeout/models/res_users.py
+++ b/auth_session_timeout/models/res_users.py
@@ -54,10 +54,10 @@ class ResUsers(models.Model):
         return True
 
     @api.model_cr_context
-    def _auth_timeout_check(self):
+    def _auth_timeout_check(self, auth_method='user'):
         """Perform session timeout validation and expire if needed."""
 
-        if not http.request:
+        if not http.request or auth_method in ['public', 'none']:
             return
 
         session = http.request.session


### PR DESCRIPTION
Fixes #380 

When checking for session validity, ignore the check if the route being accessed has `auth` set to public or none, this will fix infinite loops when visiting `/web/login` with an expired token.

The bug does't happen frequently, but it is there.

A side effect for this is that, if the module is being used for purposes other than security, for example counting the user's session time for payroll, it may cause an unexpected behaviour, but security wise it shouldn't be a problem, since the `auth` parameter is set in the backend code and if it is set to `public` or `none` then this route doesn't even need authentication.