### PR TITLE
[14.0][FIX] auth_signup_verify_email: Use real email address for tests 

### DIFF
--- a/auth_signup_verify_email/tests/test_verify_email.py
+++ b/auth_signup_verify_email/tests/test_verify_email.py
@@ -44,6 +44,6 @@ class UICase(HttpCase):
     @mute_logger("odoo.addons.auth_signup_verify_email.controllers.main")
     def test_good_email(self):
         """Test acceptance of good emails."""
-        self.data["login"] = "good@example.com"
+        self.data["login"] = "contributors@odoo-community.org"
         doc = self.html_doc(data=self.data)
         self.assertTrue(doc.xpath('//p[@class="alert alert-success"]'))


### PR DESCRIPTION
In one part of the CI pipeline, the IANA example domains are not accepted, getting this message from `email_validator` library:

The domain name example.com does not accept email

So we switch to a real domain for avoiding the problem, using our famous main OCA list address, which at the end, it's not secret and won't be disabled in a short future.

@Tecnativa