### PR TITLE
[13.0] backport auth_api_key: fix archived user allowed key

### DIFF
--- a/auth_api_key/models/auth_api_key.py
+++ b/auth_api_key/models/auth_api_key.py
@@ -24,6 +24,7 @@ class AuthApiKey(models.Model):
         help="""The user used to process the requests authenticated by
         the api key""",
     )
+    active = fields.Boolean(related="user_id.active")
 
     _sql_constraints = [("name_uniq", "unique(name)", "Api Key name must be unique.")]
 

--- a/auth_api_key/tests/test_auth_api_key.py
+++ b/auth_api_key/tests/test_auth_api_key.py
@@ -61,3 +61,9 @@ class TestAuthApiKey(SavepointCase):
         )
         with self.assertRaises(ValidationError):
             self.env["auth.api.key"]._retrieve_uid_from_api_key("api_key")
+
+    def test_user_archived(self):
+        demo_user = self.env.ref("base.user_demo")
+        demo_user.active = False
+        with self.assertRaises(ValidationError), self.env.cr.savepoint():
+            self.env["auth.api.key"]._retrieve_uid_from_api_key("api_key"), demo_user.id


### PR DESCRIPTION
If the user is archived his api key should not be valid anymore.

https://github.com/OCA/server-auth/pull/396