### PR TITLE
[FIX][12.0] auth_signup_verify_email: Turn off deliverability checks when testing

### DIFF
--- a/auth_signup_verify_email/tests/test_verify_email.py
+++ b/auth_signup_verify_email/tests/test_verify_email.py
@@ -44,6 +44,6 @@ class UICase(HttpCase):
     @mute_logger('odoo.addons.auth_signup_verify_email.controllers.main')
     def test_good_email(self):
         """Test acceptance of good emails."""
-        self.data["login"] = "good@example.com"
+        self.data["login"] = "test@test.com"
         doc = self.html_doc(data=self.data)
         self.assertTrue(doc.xpath('//p[@class="alert alert-success"]'))


### PR DESCRIPTION
since version 1.2.0, the underlying library checks for mx records, which we don't want during tests