### PR TITLE
[11.0][FIX] auth_session_timeout: session timeout applies only to user

### DIFF
--- a/auth_session_timeout/models/ir_http.py
+++ b/auth_session_timeout/models/ir_http.py
@@ -10,6 +10,6 @@ class IrHttp(models.AbstractModel):
     @classmethod
     def _authenticate(cls, auth_method='user'):
         res = super(IrHttp, cls)._authenticate(auth_method=auth_method)
-        if request and request.env and request.env.user:
+        if auth_method == "user" and request and request.env and request.env.user:
             request.env.user._auth_timeout_check()
         return res


### PR DESCRIPTION
Make it so session timeout doe not apply to requests
to a route with auth_method="public".

Backported from #258