### PR TITLE
[13.0][FIX] vault: complete_name not computed when created from other entry

### DIFF
--- a/vault/views/vault_entry_views.xml
+++ b/vault/views/vault_entry_views.xml
@@ -53,6 +53,7 @@
                                 name="parent_id"
                                 options="{'no_open': true, 'no_create_edit': true, 'no_quick_create': true}"
                             />
+                            <field name="complete_name" invisible="1" />
                             <field name="name" />
                             <field name="url" widget="url" />
                             <field name="tags" widget="many2many_tags" />


### PR DESCRIPTION
Before the path if we create a new child entry from other entry, the
complte_name of the entry is not changing when we save the new entry.
![vault_01](https://user-images.githubusercontent.com/35952655/187657437-9d690ae1-a096-446b-821f-4841edd776f7.gif)

After doing this changes, we are getting the complete_name correctly.
![vault_02](https://user-images.githubusercontent.com/35952655/187657456-cfd68825-9845-4644-b4b8-6e81a6e7198d.gif)

cc @Tecnativa TT38729

ping @victoralmau  @pedrobaeza 