### PR TITLE
[13.0][FIX] vault: Prevent 200 records limit in search panels.

### DIFF
--- a/vault/tests/test_vault.py
+++ b/vault/tests/test_vault.py
@@ -1,4 +1,5 @@
 # © 2021 Florian Kantelberg - initOS GmbH
+# Copyright 2022 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
@@ -155,3 +156,8 @@ class TestVault(TransactionCase):
         self.assertTrue(domain[0] == "|")
         self.assertIn(("expire_date", "=", False), domain)
         self.assertTrue(any(("expire_date", ">=") == d[:2] for d in domain))
+
+    def test_vault_entry_search_panel_limit(self):
+        res = self.entry.search_panel_select_range("parent_id")
+        total_items = self.env["vault.entry"].search_count([("child_ids", "!=", False)])
+        self.assertEqual(len(res["values"]), total_items)


### PR DESCRIPTION
Changes done:
- [x] Prevent 200 records limit in search panels.
- [x] Show in the left sidebar only the records that have children.

This is quite similar to https://github.com/OCA/dms/pull/167

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT38731