### PR TITLE
[14.0][FIX] vault: complete_name not computed when created from other entry

### DIFF
--- a/vault/views/vault_entry_views.xml
+++ b/vault/views/vault_entry_views.xml
@@ -53,6 +53,7 @@
                                 name="parent_id"
                                 options="{'no_open': true, 'no_create_edit': true, 'no_quick_create': true}"
                             />
+                            <field name="complete_name" invisible="1" />
                             <field name="name" />
                             <field name="url" widget="url" />
                             <field name="tags" widget="many2many_tags" />


### PR DESCRIPTION
Before the path if we create a new child entry from other entry, the
complte_name of the entry is not changing when we save the new entry.

Doing this changes, we are getting the complete_name correctly.

TT38729

FW-PORT of https://github.com/OCA/server-auth/commit/2fdf8895573504852c7c7f307740d7067d8ae0b3

please @pedrobaeza @victoralmau review this