### PR TITLE
[14.0][FIX] vault: reencryption

### DIFF
--- a/vault/models/vault_file.py
+++ b/vault/models/vault_file.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 
 _logger = logging.getLogger(__name__)
 
@@ -15,3 +15,11 @@ class VaultFile(models.Model):
     _inherit = ["vault.abstract.field", "vault.abstract"]
 
     value = fields.Binary(attachment=False)
+
+    @api.model
+    def search_read(self, *args, **kwargs):
+        if self.env.context.get("vault_reencrypt"):
+            return super(VaultFile, self.with_context(bin_size=False)).search_read(
+                *args, **kwargs
+            )
+        return super().search_read(*args, **kwargs)

--- a/vault/views/vault_views.xml
+++ b/vault/views/vault_views.xml
@@ -70,17 +70,6 @@
                         <field name="name" />
                         <field name="user_id" />
                         <field name="note" />
-
-                        <field
-                            name="field_ids"
-                            options="{'create': False, 'delete': False}"
-                            invisible="1"
-                        />
-                        <field
-                            name="file_ids"
-                            options="{'create': False, 'delete': False}"
-                            invisible="1"
-                        />
                     </group>
 
                     <notebook>


### PR DESCRIPTION
If an user gets deleted from a vault the entire data has to be re-encrypted to provide the best security. The current implementations was creating a new master key and setting it to the first 40 people of the vault while not changing the fields/files because these weren't loaded because of invisible.

The changes will load all the rights, fields, and files of a load separatly ignoring the view definition to ensure that everything will be done correctly.