### PR TITLE
[13.0][IMP][vault] Invalidate keys

### DIFF
--- a/vault/controllers/main.py
+++ b/vault/controllers/main.py
@@ -125,4 +125,4 @@ class Controller(http.Controller):
             master_key = keys.get(right.vault_id.uuid)
 
             if isinstance(master_key, str):
-                right.key = master_key
+                right.sudo().key = master_key

--- a/vault/controllers/main.py
+++ b/vault/controllers/main.py
@@ -83,6 +83,22 @@ class Controller(http.Controller):
 
         return {"public_key": user.active_key.public}
 
+    @http.route("/vault/inbox/get", auth="user", type="json")
+    def vault_get_inbox(self):
+        inboxes = request.env.user.inbox_ids
+        return {inbox.token: inbox.key for inbox in inboxes}
+
+    @http.route("/vault/inbox/store", auth="user", type="json")
+    def vault_store_inbox(self, keys):
+        if not isinstance(keys, dict):
+            return
+
+        for inbox in request.env.user.inbox_ids:
+            key = keys.get(inbox.token)
+
+            if isinstance(key, str):
+                inbox.key = key
+
     @http.route("/vault/keys/store", auth="user", type="json")
     def vault_store_keys(self, **kwargs):
         """Store the key pair for the current user"""

--- a/vault/models/res_users.py
+++ b/vault/models/res_users.py
@@ -50,7 +50,7 @@ class ResUsers(models.Model):
         """Disable the current key and remove all accesses to the vaults"""
         self.ensure_one()
         self.active_key.write({"current": False})
-        self.vault_right_ids.unlink()
+        self.vault_right_ids.sudo().unlink()
         self.inbox_ids.unlink()
         self.env["vault"].search([])._compute_access()
         return self.action_get_vault()

--- a/vault/models/res_users.py
+++ b/vault/models/res_users.py
@@ -17,6 +17,7 @@ class ResUsers(models.Model):
     )
     keys = fields.One2many("res.users.key", "user_id", readonly=True)
     vault_right_ids = fields.One2many("vault.right", "user_id", readonly=True)
+    inbox_ids = fields.One2many("vault.inbox", "user_id")
     inbox_enabled = fields.Boolean(default=True)
     inbox_link = fields.Char(compute="_compute_inbox_link", readonly=True, store=False)
     inbox_token = fields.Char(default=lambda self: uuid4(), readonly=True)
@@ -35,12 +36,24 @@ class ResUsers(models.Model):
 
     @api.model
     def action_get_vault(self):
-        return self.sudo().env.ref("vault.action_res_users_keys").read()[0]
+        action = self.sudo().env.ref("vault.action_res_users_keys")
+        result = action.read()[0]
+        result["res_id"] = self.env.uid
+        return result
 
     def action_new_inbox_token(self):
         self.ensure_one()
         self.sudo().inbox_token = uuid4()
-        return {"type": "ir.actions.act_window_close"}
+        return self.action_get_vault()
+
+    def action_invalidate_key(self):
+        """Disable the current key and remove all accesses to the vaults"""
+        self.ensure_one()
+        self.active_key.write({"current": False})
+        self.vault_right_ids.unlink()
+        self.inbox_ids.unlink()
+        self.env["vault"].search([])._compute_access()
+        return self.action_get_vault()
 
     @api.model
     def find_user_of_inbox(self, token):

--- a/vault/models/vault_right.py
+++ b/vault/models/vault_right.py
@@ -88,6 +88,7 @@ class VaultRight(models.Model):
         return res
 
     def write(self, values):
+        # Continue with the normal access management
         res = super().write(values)
         perms = ["perm_write", "perm_delete", "perm_share", "perm_create"]
         if any(x in values for x in perms):

--- a/vault/static/src/js/vault_controller.js
+++ b/vault/static/src/js/vault_controller.js
@@ -71,8 +71,6 @@ odoo.define("vault.controller", function(require) {
          * @private
          */
         _newVaultKeyPair: async function() {
-            const master_keys = await this._rpc({route: "/vault/rights/get"});
-
             // Get the current private key
             const private_key = await vault.get_private_key();
 
@@ -82,7 +80,8 @@ odoo.define("vault.controller", function(require) {
             const public_key = await vault.get_public_key();
 
             // Re-encrypt the master keys
-            const result = {};
+            const master_keys = await this._rpc({route: "/vault/rights/get"});
+            let result = {};
             for (const uuid in master_keys) {
                 result[uuid] = await utils.wrap(
                     await utils.unwrap(master_keys[uuid], private_key),
@@ -91,6 +90,18 @@ odoo.define("vault.controller", function(require) {
             }
 
             await this._rpc({route: "/vault/rights/store", params: {keys: result}});
+
+            // Re-encrypt the inboxes to not loose it
+            const inbox_keys = await this._rpc({route: "/vault/inbox/get"});
+            result = {};
+            for (const uuid in inbox_keys) {
+                result[uuid] = await utils.wrap(
+                    await utils.unwrap(inbox_keys[uuid], private_key),
+                    public_key
+                );
+            }
+
+            await this._rpc({route: "/vault/inbox/store", params: {keys: result}});
 
             await this.reload();
         },

--- a/vault/tests/test_controller.py
+++ b/vault/tests/test_controller.py
@@ -169,3 +169,24 @@ class TestController(TransactionCase):
 
         self.controller.vault_store_right_keys({vault.uuid: "new key"})
         self.assertEqual(vault.right_ids.key, "new key")
+
+    @mute_logger("odoo.sql_db")
+    def test_vault_inbox_keys(self, request_mock):
+        request_mock.env = self.env
+        self.assertFalse(self.controller.vault_get_inbox())
+
+        inbox = self.inbox.copy({"user_id": self.env.uid})
+
+        response = self.controller.vault_get_inbox()
+        self.assertEqual(response, {inbox.token: inbox.key})
+
+    @mute_logger("odoo.sql_db")
+    def test_vault_store_inbox_key(self, request_mock):
+        request_mock.env = self.env
+        inbox = self.inbox.copy({"user_id": self.env.uid})
+        inbox.user_id = self.env.user
+
+        self.controller.vault_store_inbox(None)
+
+        self.controller.vault_store_inbox({inbox.token: "new key"})
+        self.assertEqual(inbox.key, "new key")

--- a/vault/tests/test_rights.py
+++ b/vault/tests/test_rights.py
@@ -134,8 +134,6 @@ class TestAccessRights(TransactionCase):
         with self.assertRaises(AccessError):
             right.with_user(self.user).write({"perm_share": True, "key": "abc"})
 
-        right.with_user(self.user).write({"key": "abc"})
-
     def test_user_share_granted(self):
         # Granted permission to share
         right = self.env["vault.right"].create(

--- a/vault/tests/test_rights.py
+++ b/vault/tests/test_rights.py
@@ -128,6 +128,14 @@ class TestAccessRights(TransactionCase):
         with self.assertRaises(AccessError):
             right.with_user(self.user).create({"vault_id": self.vault.id, "user_id": 2})
 
+        with self.assertRaises(AccessError):
+            right.with_user(self.user).write({"perm_share": True})
+
+        with self.assertRaises(AccessError):
+            right.with_user(self.user).write({"perm_share": True, "key": "abc"})
+
+        right.with_user(self.user).write({"key": "abc"})
+
     def test_user_share_granted(self):
         # Granted permission to share
         right = self.env["vault.right"].create(

--- a/vault/tests/test_user.py
+++ b/vault/tests/test_user.py
@@ -32,3 +32,29 @@ class TestShare(TransactionCase):
         action = self.env.ref("vault.action_res_users_keys")
 
         self.assertEqual(action.id, self.env["res.users"].action_get_vault()["id"])
+
+    def test_invalidation(self):
+        self.env["res.users.key"].store(
+            40000, "invalid", "invalid", "invalid", "invalid"
+        )
+        self.assertTrue(self.env.user.keys.filtered("current"))
+
+        vault = self.env["vault"].create({"name": "Test"})
+        self.assertTrue(vault.right_ids)
+
+        inbox = self.env["vault.inbox"].create(
+            {
+                "name": "Inbox Test",
+                "secret": "secret",
+                "iv": "iv",
+                "user_id": self.env.uid,
+                "key": "key",
+                "secret_file": "",
+                "filename": "",
+            }
+        )
+
+        self.env.user.action_invalidate_key()
+        self.assertFalse(self.env.user.keys.filtered("current"))
+        self.assertFalse(inbox.exists())
+        self.assertFalse(vault.right_ids.exists())

--- a/vault/views/res_users_views.xml
+++ b/vault/views/res_users_views.xml
@@ -47,6 +47,13 @@
                         string="New inbox link"
                         class="btn-primary"
                     />
+                    <button
+                        name="action_invalidate_key"
+                        type="object"
+                        string="Invalidate private key"
+                        class="btn-secondary"
+                        confirm="You will loose access to all vaults and your inbox. Do you want to continue?"
+                    />
                     <button special="cancel" string="Cancel" class="btn-secondary" />
                 </footer>
             </form>


### PR DESCRIPTION
This allows an user to invalidate the current key and removing all access. This should only be done if the password is lost because all access to vaults are lost.

After hitting the recreation of the inbox link stay in the view.