### PR TITLE
[12.0][IMP] auth_oidc: temporarily enable signup for user creation

### DIFF
--- a/auth_oidc/models/res_users.py
+++ b/auth_oidc/models/res_users.py
@@ -30,7 +30,6 @@ class ResUsers(models.Model):
         response = requests.post(
             oauth_provider.token_endpoint,
             data=dict(
-                client_id=oauth_provider.client_id,
                 grant_type="authorization_code",
                 code=code,
                 code_verifier=oauth_provider.code_verifier,  # PKCE


### PR DESCRIPTION
This allows to give the template user high privileges (ie internal user). Without this, you'd have to allow signup and anyone would end up as highly privileged user