### PR TITLE
[14.0][FIX] password_security: Correctly look at previous password history

### DIFF
--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -198,7 +198,7 @@ class ResUsers(models.Model):
             if recent_passes < 0:
                 recent_passes = rec_id.password_history_ids
             else:
-                recent_passes = rec_id.password_history_ids[0 : recent_passes - 1]
+                recent_passes = rec_id.password_history_ids[0 : recent_passes]
             if recent_passes.filtered(
                 lambda r: crypt.verify(password, r.password_crypt)
             ):


### PR DESCRIPTION
If a user has previous passwords stored and the `password_history` is set to 0 to disable the check, the line of code would evaluate to:

```
rec_id.password_history_ids[0:-1]
```

The above returns all items in the list except for the first last entry. One expects the above to evaluate to:

```
rec_id.password_history_ids[0:0]
```

The above returns an empty list which would then correctly not raise a warning.