### PR TITLE
[IMP] auth_saml: Lengthen test password.

### DIFF
--- a/auth_saml/tests/test_pysaml.py
+++ b/auth_saml/tests/test_pysaml.py
@@ -250,7 +250,7 @@ class TestPySaml(HttpCase):
         )
         # Assert that the user password can not be set
         with self.assertRaises(ValidationError):
-            user.password = "new password"
+            user.password = "new longer password"
 
     def test_disallow_user_password(self):
         """Test that existing user password is deleted when adding an SAML provider when


### PR DESCRIPTION
This should avoid a test failure caused by the incoming password_security module.

https://github.com/OCA/server-auth/actions/runs/3821746350/jobs/6501199387#step:8:615