### PR TITLE
[FIX][14.0]users_ldap_mail force the cast in string in case of the Active directory is prov…

### DIFF
--- a/users_ldap_mail/models/users_ldap_model.py
+++ b/users_ldap_mail/models/users_ldap_model.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from odoo import fields, models
+from odoo import fields, models, tools
 
 _logger = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ class CompanyLDAP(models.Model):
         for value_key, conf_name in mapping:
             try:
                 if conf[conf_name]:
-                    values[value_key] = ldap_entry[1][conf[conf_name]][0]
+                    values[value_key] = tools.ustr(ldap_entry[1][conf[conf_name]][0])
             except KeyError:
                 _logger.warning(
                     'No LDAP attribute "%s" found for login  "%s"'


### PR DESCRIPTION
…inding byte-code strings

when working with AD, email are sometimes returned as byte-code issuing this message :
```
  File "/home/odoo_14_upa/additionnal_repositories/OCA-partner-contact/partner_email_check/models/res_partner.py", line 37, in email_check
    for email in emails.split(",")
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/odoo_14_upa/server/odoo/http.py", line 641, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/odoo_14_upa/server/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
TypeError: a bytes-like object is required, not 'str'
```

This fix handle this case already used in other part of this module