### PR TITLE
[13.0][IMP] timeout check triggered on session uid

### DIFF
--- a/auth_session_timeout/models/ir_http.py
+++ b/auth_session_timeout/models/ir_http.py
@@ -10,6 +10,6 @@ class IrHttp(models.AbstractModel):
     @classmethod
     def _authenticate(cls, auth_method="user"):
         res = super(IrHttp, cls)._authenticate(auth_method=auth_method)
-        if auth_method == "user" and request and request.env and request.env.user:
+        if request and request.session and request.session.uid:
             request.env.user._auth_timeout_check()
         return res


### PR DESCRIPTION
The same reasoning as in https://github.com/OCA/server-auth/pull/338 :
"Triggering timeout check on request session.uid, because env.user may be null.
env,user._auth_timeout_check will work with an empty recordset ( it is @api.model_cr_context)"

Also in my own testing the old code does not work in all the cases. If you refresh the page (or open a new page) the timeout won't happen. Only if you use Odoo UI, i.e. push interface buttons, the timeout happens.

As a side note, this change perhaps should be done for newer version (14.0+), but I have not tested these versions.
