### PR TITLE
[15.0][ADD] auth_saml: Improve login page

### DIFF
--- a/auth_saml/__manifest__.py
+++ b/auth_saml/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "XCG Consulting, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/server-auth",
     "license": "AGPL-3",
-    "depends": ["base_setup"],
+    "depends": ["base_setup", "web"],
     "external_dependencies": {
         # Place an upper bound on cryptography version to be compatible with
         # pyopenssl 19 mentioned in Odoo 15's requirements.txt. If we don't do

--- a/auth_saml/controllers/main.py
+++ b/auth_saml/controllers/main.py
@@ -68,10 +68,6 @@ class SAMLLogin(Home):
             domain.append(("autoredirect", "=", True))
         providers = request.env["auth.saml.provider"].sudo().search_read(domain)
 
-        for provider in providers:
-            # Compatibility with auth_oauth/controllers/main.py in order to
-            # avoid KeyError rendering template_auth_oauth_providers
-            provider.setdefault("auth_link", "")
         return providers
 
     def _saml_autoredirect(self):
@@ -131,7 +127,7 @@ class SAMLLogin(Home):
             else:
                 error = None
 
-            response.qcontext["providers"] = providers
+            response.qcontext["saml_providers"] = providers
 
             if error:
                 response.qcontext["error"] = error

--- a/auth_saml/models/auth_saml_provider.py
+++ b/auth_saml/models/auth_saml_provider.py
@@ -87,8 +87,11 @@ class AuthSamlProvider(models.Model):
     css_class = fields.Char(
         string="Button Icon CSS class",
         help="Add a CSS class that serves you to style the login button.",
+        default="fa fa-fw fa-sign-in text-primary",
     )
-    body = fields.Char(string="Button Description")
+    body = fields.Char(
+        string="Login button label", help="Link text in Login Dialog", translate=True
+    )
     autoredirect = fields.Boolean(
         "Automatic Redirection",
         default=False,

--- a/auth_saml/readme/CONTRIBUTORS.rst
+++ b/auth_saml/readme/CONTRIBUTORS.rst
@@ -1,8 +1,10 @@
-* Florent Aide <florent.aide@xcg-consulting.fr>
-* Vincent Hatakeyama <vincent.hatakeyama@xcg-consulting.fr>
-* Alexandre Brun <alexandre.brun@xcg-consulting.fr>
+* XCG Consulting, part of `Orbeet <https://orbeet.io>`__:
+
+  * Florent Aide <florent.aide@xcg-consulting.fr>
+  * Vincent Hatakeyama <vincent.hatakeyama@xcg-consulting.fr>
+  * Alexandre Brun
+  * Houzéfa Abbasbhay <houzefa.abba@xcg-consulting.fr>
 * Jeremy Co Kim Len <jeremy.cokimlen@vinci-concessions.com>
-* Houzéfa Abbasbhay <houzefa.abba@xcg-consulting.fr>
 * Jeffery Chen Fan <jeffery9@gmail.com>
 * Bhavesh Odedra <bodedra@opensourceintegrators.com>
 * `Tecnativa <https://www.tecnativa.com/>`__:

--- a/auth_saml/views/auth_saml.xml
+++ b/auth_saml/views/auth_saml.xml
@@ -2,25 +2,28 @@
 <odoo>
     <!-- login form button -->
     <template id="auth_saml.providers" name="Auth SAML Providers">
-        <t t-if="len(providers) &gt; 0">
+        <t t-if="len(saml_providers) &gt; 0">
             <em
                 t-attf-class="d-block text-center text-muted small my-#{len(providers) if len(providers) &lt; 3 else 3}"
             >- or -</em>
-            <div class="o_login_saml2 mt-1 mb-1 text-left">
-                <t t-foreach="providers" t-as="p">
-                    <a
-                        t-att-href="'/auth_saml/get_auth_request?pid=%s'%p['id']"
-                        class="btn btn-outline-primary btn-block"
-                    >
-                        <i t-att-class="p['css_class']" />
-                        <t t-esc="p['body']" />
-                    </a>
-                </t>
+            <div class="o_login_saml2 list-group mt-1 mb-1 text-left">
+                <a
+                    t-foreach="saml_providers"
+                    t-as="p"
+                    class="list-group-item list-group-item-action py-2"
+                    t-att-href="'/auth_saml/get_auth_request?pid=%s'%p['id']"
+                >
+                    <i t-att-class="p['css_class']" />
+                    <t t-esc="p['body']" />
+                </a>
             </div>
         </t>
     </template>
     <template id="auth_saml.login" inherit_id="web.login" name="Samlv2 Login buttons">
-        <xpath expr="//div[hasclass('o_login_auth')]" position="after">
+        <xpath expr="//form" position="before">
+            <t t-set="form_small" t-value="True" t-if="len(saml_providers) &gt; 2" />
+        </xpath>
+        <xpath expr="//div[hasclass('o_login_auth')]" position="inside">
             <t t-call="auth_saml.providers" />
         </xpath>
     </template>


### PR DESCRIPTION
Make the login page compatible with auth_oauth by using a differently named variable.

Render the button with the similar classes and HTML as what is done by auth_oauth. That includes using the default CSS and adding translation for the button text.

Images of the Login buttons with both auth_oauth and auth_saml:

Before the changes:

![Capture d’écran de 2023-02-20 11-22-05](https://user-images.githubusercontent.com/6304302/220084873-d5dfebca-313b-40ea-b8af-23bbbcddc452.png)

After the changes:

![Capture d’écran de 2023-02-20 11-39-42](https://user-images.githubusercontent.com/6304302/220084940-9da93db3-4b3a-4351-8ddd-0868b8a81191.png)