### PR TITLE
[15.0][ADD] auth_saml: handle redirect parameter in the URI

### DIFF
--- a/auth_saml/controllers/main.py
+++ b/auth_saml/controllers/main.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020 GlodoUK <https://www.glodo.uk/>
-# Copyright (C) 2010-2016, 2022 XCG Consulting <https://xcg-consulting.fr/>
+# Copyright (C) 2010-2016, 2022-2023 XCG Consulting <https://xcg-consulting.fr/>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import functools
@@ -7,6 +7,7 @@ import json
 import logging
 
 import werkzeug.utils
+from werkzeug.exceptions import BadRequest
 from werkzeug.urls import url_quote_plus
 
 import odoo
@@ -54,7 +55,7 @@ def fragment_to_query_string(func):
 
 
 class SAMLLogin(Home):
-    def _list_saml_providers_domain(self):
+    def _list_saml_providers_domain(self):  # pylint: disable=no-self-use
         return []
 
     def list_saml_providers(self, with_autoredirect: bool = False) -> models.Model:
@@ -67,7 +68,8 @@ class SAMLLogin(Home):
         if with_autoredirect:
             domain.append(("autoredirect", "=", True))
         providers = request.env["auth.saml.provider"].sudo().search_read(domain)
-
+        for provider in providers:
+            provider["auth_link"] = self._auth_saml_request_link(provider)
         return providers
 
     def _saml_autoredirect(self):
@@ -79,10 +81,20 @@ class SAMLLogin(Home):
         )
         if autoredirect_providers and not disable_autoredirect:
             return werkzeug.utils.redirect(
-                "/auth_saml/get_auth_request?pid=%d" % autoredirect_providers[0]["id"],
+                self._auth_saml_request_link(autoredirect_providers[0]),
                 303,
             )
         return None
+
+    def _auth_saml_request_link(self, provider: models.Model):
+        """Return the auth request link for the provided provider"""
+        params = {
+            "pid": provider["id"],
+        }
+        redirect = request.params.get("redirect")
+        if redirect:
+            params["redirect"] = redirect
+        return "/auth_saml/get_auth_request?%s" % werkzeug.urls.url_encode(params)
 
     @http.route()
     def web_client(self, s_action=None, **kw):
@@ -144,7 +156,6 @@ class AuthSAMLController(http.Controller):
         The provider will automatically set things like the dbname, provider
         id, etc.
         """
-
         redirect = request.params.get("redirect") or "web"
         if not redirect.startswith(("//", "http://", "https://")):
             redirect = "{}{}".format(
@@ -199,6 +210,8 @@ class AuthSAMLController(http.Controller):
         state = json.loads(kw["RelayState"])
         provider = state["p"]
         dbname = state["d"]
+        if not http.db_filter([dbname]):
+            return BadRequest()
         context = state.get("c", {})
         registry = registry_get(dbname)
 
@@ -216,8 +229,15 @@ class AuthSAMLController(http.Controller):
                 )
                 action = state.get("a")
                 menu = state.get("m")
+                redirect = (
+                    werkzeug.urls.url_unquote_plus(state["r"])
+                    if state.get("r")
+                    else False
+                )
                 url = "/"
-                if action:
+                if redirect:
+                    url = redirect
+                elif action:
                     url = "/#action=%s" % action
                 elif menu:
                     url = "/#menu_id=%s" % menu

--- a/auth_saml/models/auth_saml_provider.py
+++ b/auth_saml/models/auth_saml_provider.py
@@ -191,7 +191,7 @@ class AuthSamlProvider(models.Model):
 
         return keys_path
 
-    def _get_config_for_provider(self, base_url: str = None):
+    def _get_config_for_provider(self, base_url: str = None) -> Saml2Config:
         """
         Internal helper to get a configured Saml2Client
         """
@@ -237,7 +237,7 @@ class AuthSamlProvider(models.Model):
         sp_config.allow_unknown_attributes = True
         return sp_config
 
-    def _get_client_for_provider(self, base_url: str = None):
+    def _get_client_for_provider(self, base_url: str = None) -> Saml2Client:
         sp_config = self._get_config_for_provider(base_url)
         saml_client = Saml2Client(config=sp_config)
         return saml_client
@@ -336,7 +336,7 @@ class AuthSamlProvider(models.Model):
             {"saml_provider_id": self.id, "saml_request_id": reqid}
         )
 
-    def _metadata_string(self, valid=None, base_url=None):
+    def _metadata_string(self, valid=None, base_url: str = None):
         self.ensure_one()
 
         sp_config = self._get_config_for_provider(base_url)

--- a/auth_saml/readme/HISTORY.rst
+++ b/auth_saml/readme/HISTORY.rst
@@ -1,3 +1,13 @@
+15.0.1.4.0
+~~~~~~~~~~
+
+Handle redirect after authentification.
+
+15.0.1.3.0
+~~~~~~~~~~
+
+Improve login page.
+
 15.0.1.1.0
 ~~~~~~~~~~
 

--- a/auth_saml/views/auth_saml.xml
+++ b/auth_saml/views/auth_saml.xml
@@ -11,7 +11,7 @@
                     t-foreach="saml_providers"
                     t-as="p"
                     class="list-group-item list-group-item-action py-2"
-                    t-att-href="'/auth_saml/get_auth_request?pid=%s'%p['id']"
+                    t-att-href="p['auth_link']"
                 >
                     <i t-att-class="p['css_class']" />
                     <t t-esc="p['body']" />


### PR DESCRIPTION
Includes #481

Unlike auth_oauth, this module did not handle redirect correctly.

For example, something like http://localhost:8069/web/login?redirect=%2Fweb%23menu_id%3D111%26action%3D176%26model%3Dmodel_name%26view_type%3Dlist would not keep the redirect part if SAML authentication was used. It would work as expected with the standard authentication or auth_oauth/auth_oidc.

The changes have been tested with a local keycloak.