### PR TITLE
[16.0][IMP] auth_api_key: Implement 'public_or_api_key' authentication method

### DIFF
--- a/auth_api_key/models/ir_http.py
+++ b/auth_api_key/models/ir_http.py
@@ -34,3 +34,9 @@ class IrHttp(models.AbstractModel):
                 return True
         _logger.error("Wrong HTTP_API_KEY, access denied")
         raise AccessDenied()
+
+    @classmethod
+    def _auth_method_public_or_api_key(cls):
+        if "HTTP_API_KEY" not in request.httprequest.environ:
+            return cls._auth_method_public()
+        return cls._auth_method_api_key()


### PR DESCRIPTION
This method is useful to allows to access to a route publicly or already authenticated by an api key.