### PR TITLE
[15.0][IMP] password_security: Calculate score correctly w/o char type reqs.

### DIFF
--- a/password_security/__manifest__.py
+++ b/password_security/__manifest__.py
@@ -32,6 +32,9 @@
             "/password_security/static/src/js/password_gauge.js",
             "/password_security/static/lib/zxcvbn/zxcvbn.min.js",
         ],
+        "web.qunit_suite_tests": [
+            "password_security/static/tests/**/*",
+        ],
     },
     "demo": [
         "demo/res_users.xml",

--- a/password_security/static/src/js/password_gauge.js
+++ b/password_security/static/src/js/password_gauge.js
@@ -14,20 +14,20 @@ odoo.define("password_security.policy", function (require) {
          *
          * @param {Object} info
          * @param {Number} [info.password_length=4]
-         * @param {Number} [info.password_lower=1]
-         * @param {Number} [info.password_upper=1]
-         * @param {Number} [info.password_numeric=1]
-         * @param {Number} [info.password_special=1]
+         * @param {Number} [info.password_lower]
+         * @param {Number} [info.password_upper]
+         * @param {Number} [info.password_numeric]
+         * @param {Number} [info.password_special]
          * @param {Number} [info.password_estimate=3]
          */
         init: function (info) {
             this._super(info);
 
             this._password_length = info.password_length || 4;
-            this._password_lower = info.password_lower || 1;
-            this._password_upper = info.password_upper || 1;
-            this._password_numeric = info.password_numeric || 1;
-            this._password_special = info.password_special || 1;
+            this._password_lower = info.password_lower;
+            this._password_upper = info.password_upper;
+            this._password_numeric = info.password_numeric;
+            this._password_special = info.password_special;
             this._password_estimate = info.password_estimate || 3;
         },
 
@@ -79,6 +79,10 @@ odoo.define("password_security.policy", function (require) {
         },
 
         _calculate_password_score: function (pattern, min_count, password) {
+            if (!min_count) {
+                return 1.0;
+            }
+
             var matchMinCount = new RegExp(
                 "(.*" + pattern + ".*){" + min_count + ",}",
                 "g"

--- a/password_security/static/tests/auth_password_policy_tests.js
+++ b/password_security/static/tests/auth_password_policy_tests.js
@@ -1,0 +1,39 @@
+odoo.define("password_security.auth_password_policy_tests", function (require) {
+    "use strict";
+
+    /* global QUnit */
+
+    var Policy = require("auth_password_policy").Policy;
+
+    QUnit.module("auth_password_policy", {}, function () {
+        QUnit.test("Policy.score", async function (assert) {
+            var info = {
+                password_length: 4,
+                password_upper: 1,
+                password_lower: 1,
+                password_numeric: 1,
+                password_special: 1,
+                password_estimate: 3,
+            };
+
+            var base = new Policy(info);
+            assert.ok(base.score("aB3!") > 0, "pass: " + base.toString());
+
+            var policy = new Policy(_.extend({}, info, {password_lower: 0}));
+            assert.ok(policy.score("AB3!") > 0, "pass: " + policy.toString());
+            assert.equal(base.score("AB3!"), 0, "fail: " + base.toString());
+
+            policy = new Policy(_.extend({}, info, {password_numeric: 0}));
+            assert.ok(policy.score("aBc!") > 0, "pass: " + policy.toString());
+            assert.equal(base.score("aBc!"), 0, "fail: " + base.toString());
+
+            policy = new Policy(_.extend({}, info, {password_special: 0}));
+            assert.ok(policy.score("aB3d") > 0, "pass: " + policy.toString());
+            assert.equal(base.score("aB3d"), 0, "fail: " + base.toString());
+
+            policy = new Policy(_.extend({}, info, {password_upper: 0}));
+            assert.ok(policy.score("ab3!") > 0, "pass: " + policy.toString());
+            assert.equal(base.score("ab3!"), 0, "fail: " + base.toString());
+        });
+    });
+});


### PR DESCRIPTION
The default values in `auth_password_policy.Policy.init` make it impossible to disable character type requirements, so they have been removed.

Blocks #464.