### PR TITLE
[15.0][FIX] password_security: constraint of password_estimate range

### DIFF
--- a/password_security/models/res_company.py
+++ b/password_security/models/res_company.py
@@ -58,5 +58,5 @@ class ResCompany(models.Model):
 
     @api.constrains("password_estimate")
     def _check_password_estimate(self):
-        if 0 > self.password_estimate > 4:
+        if self.password_estimate < 0 or self.password_estimate > 4:
             raise ValidationError(_("The estimation must be between 0 and 4."))

--- a/password_security/readme/CONTRIBUTORS.rst
+++ b/password_security/readme/CONTRIBUTORS.rst
@@ -10,3 +10,6 @@
 
     * Chandresh Thakkar <cthakkar@opensourceintegrators.com>
     * Daniel Reis <dreis@opensourceintegrators.com>
+
+* `Onestein <https://www.onestein.nl>`_:
+    * Andrea Stirpe <a.stirpe@onestein.nl>

--- a/password_security/tests/__init__.py
+++ b/password_security/tests/__init__.py
@@ -4,5 +4,6 @@
 from . import (
     test_password_security_home,
     test_password_security_session,
+    test_res_config_settings,
     test_res_users,
 )

--- a/password_security/tests/test_res_config_settings.py
+++ b/password_security/tests/test_res_config_settings.py
@@ -1,0 +1,24 @@
+# Copyright 2023 Onestein (<https://www.onestein.eu>)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+
+
+class TestConfigSettings(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.config = cls.env["res.config.settings"].create({})
+
+    def test_01_password_estimate_range(self):
+        """The estimation must be between 0 and 4"""
+        self.config.password_estimate = 0
+        self.config.password_estimate = 2
+        self.config.password_estimate = 4
+
+        with self.assertRaises(ValidationError):
+            self.config.password_estimate = 5
+
+        with self.assertRaises(ValidationError):
+            self.config.password_estimate = -1


### PR DESCRIPTION
This fixes the computation of constraint of password_estimate range. Without this fix, the constraint never raises an error.
Backported from https://github.com/OCA/server-auth/pull/482