### PR TITLE
[15.0][FIX] password_security: Reset Password issue

### DIFF
--- a/password_security/__manifest__.py
+++ b/password_security/__manifest__.py
@@ -7,6 +7,7 @@
     "summary": "Allow admin to set password security requirements.",
     "version": "15.0.1.0.0",
     "author": "LasLabs, "
+    "Onestein, "
     "Kaushal Prajapati, "
     "Tecnativa, "
     "initOS GmbH, "

--- a/password_security/controllers/main.py
+++ b/password_security/controllers/main.py
@@ -58,29 +58,3 @@ class PasswordSecurityHome(AuthSignupHome):
             qcontext = self.get_auth_signup_qcontext()
             qcontext["error"] = str(e)
             return request.render("auth_signup.signup", qcontext)
-
-    @http.route()
-    def web_auth_reset_password(self, *args, **kw):
-        """It provides hook to disallow front-facing resets inside of min
-        Unfortuantely had to reimplement some core logic here because of
-        nested logic in parent
-        """
-        qcontext = self.get_auth_signup_qcontext()
-        if (
-            request.httprequest.method == "POST"
-            and qcontext.get("login")
-            and "error" not in qcontext
-            and "token" not in qcontext
-        ):
-            login = qcontext.get("login")
-            user_ids = request.env.sudo().search(
-                [("login", "=", login)],
-                limit=1,
-            )
-            if not user_ids:
-                user_ids = request.env.sudo().search(
-                    [("email", "=", login)],
-                    limit=1,
-                )
-            user_ids._validate_pass_reset()
-        return super(PasswordSecurityHome, self).web_auth_reset_password(*args, **kw)

--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -164,11 +164,11 @@ class ResUsers(models.Model):
         :raises: UserError on invalidated pass reset attempt
         :return: True on allowed reset
         """
-        for rec_id in self:
-            pass_min = rec_id.company_id.password_minimum
+        for user in self:
+            pass_min = user.company_id.password_minimum
             if pass_min <= 0:
-                pass
-            write_date = rec_id.password_write_date
+                continue
+            write_date = user.password_write_date
             delta = timedelta(hours=pass_min)
             if write_date + delta > datetime.now():
                 raise UserError(
@@ -205,3 +205,13 @@ class ResUsers(models.Model):
 
         self.write({"password_history_ids": [(0, 0, {"password_crypt": pw})]})
         return res
+
+    def action_reset_password(self):
+        """Disallow password resets inside of Minimum Hours"""
+        if not self.env.context.get("install_mode") and not self.env.context.get(
+            "create_user"
+        ):
+            if not self.env.user._is_admin():
+                users = self.filtered(lambda user: user.active)
+                users._validate_pass_reset()
+        return super().action_reset_password()

--- a/password_security/readme/CONTRIBUTORS.rst
+++ b/password_security/readme/CONTRIBUTORS.rst
@@ -10,3 +10,6 @@
 
     * Chandresh Thakkar <cthakkar@opensourceintegrators.com>
     * Daniel Reis <dreis@opensourceintegrators.com>
+
+* `Onestein <https://www.onestein.nl>`_:
+    * Andrea Stirpe <a.stirpe@onestein.nl>

--- a/password_security/tests/__init__.py
+++ b/password_security/tests/__init__.py
@@ -5,4 +5,5 @@ from . import (
     test_password_security_home,
     test_password_security_session,
     test_res_users,
+    test_reset_password,
 )

--- a/password_security/tests/test_password_security_home.py
+++ b/password_security/tests/test_password_security_home.py
@@ -172,50 +172,6 @@ class TestPasswordSecurityHome(TransactionCase):
                     res,
                 )
 
-    def test_web_auth_reset_password_fail_login(self):
-        """It should raise from failed _validate_pass_reset by login"""
-        with self.mock_assets() as assets:
-            with mock.patch.object(
-                main.AuthSignupHome, "get_auth_signup_qcontext", spec=dict
-            ) as qcontext:
-                qcontext["login"] = "login"
-                search = assets["request"].env.sudo().search
-                assets["request"].httprequest.method = "POST"
-                user = mock.MagicMock()
-                user._validate_pass_reset.side_effect = MockPassError
-                search.return_value = user
-                with self.assertRaises(MockPassError):
-                    self.password_security_home.web_auth_reset_password()
-
-    def test_web_auth_reset_password_fail_email(self):
-        """It should raise from failed _validate_pass_reset by email"""
-        with self.mock_assets() as assets:
-            with mock.patch.object(
-                main.AuthSignupHome, "get_auth_signup_qcontext", spec=dict
-            ) as qcontext:
-                qcontext["login"] = "login"
-                search = assets["request"].env.sudo().search
-                assets["request"].httprequest.method = "POST"
-                user = mock.MagicMock()
-                user._validate_pass_reset.side_effect = MockPassError
-                search.side_effect = [[], user]
-                with self.assertRaises(MockPassError):
-                    self.password_security_home.web_auth_reset_password()
-
-    def test_web_auth_reset_password_success(self):
-        """It should return parent response on no validate errors"""
-        with self.mock_assets() as assets:
-            with mock.patch.object(
-                main.AuthSignupHome, "get_auth_signup_qcontext", spec=dict
-            ) as qcontext:
-                qcontext["login"] = "login"
-                assets["request"].httprequest.method = "POST"
-                res = self.password_security_home.web_auth_reset_password()
-                self.assertEqual(
-                    assets["web_auth_reset_password"](),
-                    res,
-                )
-
 
 @mock.patch("odoo.http.WebRequest.validate_csrf", return_value=True)
 class LoginCase(HttpCase):

--- a/password_security/tests/test_reset_password.py
+++ b/password_security/tests/test_reset_password.py
@@ -1,0 +1,87 @@
+# Copyright 2023 Onestein (<https://www.onestein.eu>)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo import http
+from odoo.exceptions import UserError
+from odoo.tests.common import HttpCase, Opener, get_db_name, new_test_user, tagged
+
+
+@tagged("-at_install", "post_install")
+class TestPasswordSecurityReset(HttpCase):
+    def setUp(self):
+        super().setUp()
+
+        # Create user with strong password: no error raised
+        new_test_user(self.env, "jackoneill", password="!asdQWE12345_3")
+
+    def reset_password(self, username):
+        """Reset user password"""
+        db = get_db_name()
+        self.session = session = http.root.session_store.new()
+        session.db = db
+        http.root.session_store.save(session)
+
+        self.opener = Opener(self.cr)
+        self.opener.cookies["session_id"] = session.sid
+
+        res_post = self.url_open(
+            "/web/reset_password",
+            data={
+                "login": username,
+                "name": username,
+                "csrf_token": http.WebRequest.csrf_token(self),
+            },
+        )
+        res_post.raise_for_status()
+
+        return res_post
+
+    def test_01_reset_password_fail(self):
+        """It should fail when reset password below Minimum Hours"""
+        # Enable check on Minimum Hours
+        self.env.company.password_minimum = 24
+
+        # Reset password
+        response = self.reset_password("jackoneill")
+
+        # Ensure we stay in the reset password page
+        self.assertEqual(response.request.path_url, "/web/reset_password")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "Passwords can only be reset every %s hour(s). "
+            "Please contact an administrator for assistance."
+            % self.env.company.password_minimum,
+            response.text,
+        )
+
+    def test_02_reset_password_success(self):
+        """It should succeed when check on Minimum Hours is disabled"""
+
+        # Disable check on Minimum Hours
+        self.env.company.password_minimum = 0
+
+        # Reset password
+        response = self.reset_password("jackoneill")
+
+        # Password reset instructions sent to user's email
+        self.assertEqual(response.request.path_url, "/web/reset_password")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "An email has been sent with credentials to reset your password",
+            response.text,
+        )
+
+    def test_03_reset_password_admin(self):
+        """It should succeed when reset password is executed by Admin"""
+        # Enable check on Minimum Hours
+        self.env.company.password_minimum = 24
+
+        # Executed by Admin: no error is raised
+        self.assertTrue(self.env.user._is_admin())
+        self.env["res.users"].reset_password("demo")
+
+        # Executed by non-admin user: error is raised
+        self.env = self.env(user=self.env.ref("base.user_demo"))
+        self.assertFalse(self.env.user._is_admin())
+        with self.assertRaises(UserError):
+            self.env["res.users"].reset_password("demo")


### PR DESCRIPTION
Fixes the Reset Password issue described in https://github.com/OCA/server-auth/issues/54.
The fix is backported from https://github.com/OCA/server-auth/pull/482.
Replaces mocked tests for password reset, as they were not capable to test the code properly.
