### PR TITLE
[14.0][IMP] auth_api_key: archive key when user is archived

### DIFF
--- a/auth_api_key/__manifest__.py
+++ b/auth_api_key/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Auth Api Key",
     "summary": """
         Authenticate http requests from an API key""",
-    "version": "14.0.2.2.1",
+    "version": "14.0.3.0.0",
     "license": "LGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/server-auth",

--- a/auth_api_key/__manifest__.py
+++ b/auth_api_key/__manifest__.py
@@ -10,5 +10,10 @@
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/server-auth",
     "development_status": "Production/Stable",
-    "data": ["security/ir.model.access.csv", "views/auth_api_key.xml"],
+    "depends": ["base_setup"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/auth_api_key.xml",
+        "views/res_config_settings.xml",
+    ],
 }

--- a/auth_api_key/migrations/14.0.3.0.0/pre-migrate.py
+++ b/auth_api_key/migrations/14.0.3.0.0/pre-migrate.py
@@ -1,0 +1,15 @@
+# Copyright 2023 Camptocamp SA
+# @author: Simone Orsi <simone.orsi@camptocamp.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import logging
+
+from odoo.tools import sql
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    # Stay backward compatible with having an active key for an archived user
+    sql.create_column(cr, "auth_api_key", "active", "BOOLEAN")
+    cr.execute("UPDATE auth_api_key set active=true;")

--- a/auth_api_key/models/__init__.py
+++ b/auth_api_key/models/__init__.py
@@ -1,2 +1,4 @@
 from . import ir_http
 from . import auth_api_key
+from . import res_company
+from . import res_config_settings

--- a/auth_api_key/models/auth_api_key.py
+++ b/auth_api_key/models/auth_api_key.py
@@ -23,9 +23,11 @@ class AuthApiKey(models.Model):
         help="""The user used to process the requests authenticated by
         the api key""",
     )
-    # Not using related to stay backward compatible with having active key
-    # for an archived user (no need to be charged on active user for the api)
-    active = fields.Boolean(compute="_compute_active", readonly=False, store=True)
+    # Not using related to stay backward compatible with having active keys
+    # for archived users (no need being invoiced by Odoo for api request users)
+    active = fields.Boolean(
+        compute="_compute_active", readonly=False, store=True, default=True
+    )
 
     _sql_constraints = [("name_uniq", "unique(name)", "Api Key name must be unique.")]
 
@@ -52,10 +54,16 @@ class AuthApiKey(models.Model):
         self._retrieve_api_key_id.clear_cache(self.env[self._name])
         self._retrieve_uid_from_api_key.clear_cache(self.env[self._name])
 
-    @api.depends("user_id.active")
+    @api.depends(
+        "user_id.active", "user_id.company_id.archived_user_disable_auth_api_key"
+    )
     def _compute_active(self):
+        option_disable_key = self.user_id.company_id.archived_user_disable_auth_api_key
         for record in self:
-            record.active = record.user_id.active
+            if option_disable_key:
+                record.active = record.user_id.active
+            # To stay coherent if the option is disabled the active field is not
+            # changed. Because the field is stored, it should not be an issue.
 
     @api.model
     def create(self, vals):

--- a/auth_api_key/models/auth_api_key.py
+++ b/auth_api_key/models/auth_api_key.py
@@ -23,6 +23,9 @@ class AuthApiKey(models.Model):
         help="""The user used to process the requests authenticated by
         the api key""",
     )
+    # Not using related to stay backward compatible with having active key
+    # for an archived user (no need to be charged on active user for the api)
+    active = fields.Boolean(compute="_compute_active", readonly=False, store=True)
 
     _sql_constraints = [("name_uniq", "unique(name)", "Api Key name must be unique.")]
 
@@ -48,6 +51,11 @@ class AuthApiKey(models.Model):
     def _clear_key_cache(self):
         self._retrieve_api_key_id.clear_cache(self.env[self._name])
         self._retrieve_uid_from_api_key.clear_cache(self.env[self._name])
+
+    @api.depends("user_id.active")
+    def _compute_active(self):
+        for record in self:
+            record.active = record.user_id.active
 
     @api.model
     def create(self, vals):

--- a/auth_api_key/models/res_company.py
+++ b/auth_api_key/models/res_company.py
@@ -1,0 +1,17 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    archived_user_disable_auth_api_key = fields.Boolean(
+        string="Disable API key for archived user",
+        help=(
+            "If checked, when a user is archived/unactivated the same change is "
+            "propagated to his related api key. It is not retroactive (nothing is done "
+            " when enabling/disabling this option)."
+        ),
+    )

--- a/auth_api_key/models/res_config_settings.py
+++ b/auth_api_key/models/res_config_settings.py
@@ -1,0 +1,12 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    archived_user_disable_auth_api_key = fields.Boolean(
+        related="company_id.archived_user_disable_auth_api_key", readonly=False
+    )

--- a/auth_api_key/tests/test_auth_api_key.py
+++ b/auth_api_key/tests/test_auth_api_key.py
@@ -43,3 +43,16 @@ class TestAuthApiKey(SavepointCase):
         )
         with self.assertRaises(ValidationError):
             self.env["auth.api.key"]._retrieve_uid_from_api_key("api_key")
+
+    def test_user_archived_unarchived(self):
+        demo_user = self.env.ref("base.user_demo")
+        self.assertEqual(
+            self.env["auth.api.key"]._retrieve_uid_from_api_key("api_key"), demo_user.id
+        )
+        demo_user.active = False
+        with self.assertRaises(ValidationError):
+            self.env["auth.api.key"]._retrieve_uid_from_api_key("api_key")
+        demo_user.active = True
+        self.assertEqual(
+            self.env["auth.api.key"]._retrieve_uid_from_api_key("api_key"), demo_user.id
+        )

--- a/auth_api_key/tests/test_auth_api_key.py
+++ b/auth_api_key/tests/test_auth_api_key.py
@@ -44,7 +44,8 @@ class TestAuthApiKey(SavepointCase):
         with self.assertRaises(ValidationError):
             self.env["auth.api.key"]._retrieve_uid_from_api_key("api_key")
 
-    def test_user_archived_unarchived(self):
+    def test_user_archived_unarchived_with_option_on(self):
+        self.env.company.archived_user_disable_auth_api_key = True
         demo_user = self.env.ref("base.user_demo")
         self.assertEqual(
             self.env["auth.api.key"]._retrieve_uid_from_api_key("api_key"), demo_user.id
@@ -53,6 +54,17 @@ class TestAuthApiKey(SavepointCase):
         with self.assertRaises(ValidationError):
             self.env["auth.api.key"]._retrieve_uid_from_api_key("api_key")
         demo_user.active = True
+        self.assertEqual(
+            self.env["auth.api.key"]._retrieve_uid_from_api_key("api_key"), demo_user.id
+        )
+
+    def test_user_archived_unarchived_with_option_off(self):
+        self.env.company.archived_user_disable_auth_api_key = False
+        demo_user = self.env.ref("base.user_demo")
+        self.assertEqual(
+            self.env["auth.api.key"]._retrieve_uid_from_api_key("api_key"), demo_user.id
+        )
+        demo_user.active = False
         self.assertEqual(
             self.env["auth.api.key"]._retrieve_uid_from_api_key("api_key"), demo_user.id
         )

--- a/auth_api_key/views/auth_api_key.xml
+++ b/auth_api_key/views/auth_api_key.xml
@@ -8,6 +8,13 @@
         <field name="arch" type="xml">
             <form create="false" edit="false">
                 <sheet>
+                  <field name="active" invisible="1" />
+                  <widget
+                        name="web_ribbon"
+                        title="Archived"
+                        bg_color="bg-danger"
+                        attrs="{'invisible': [('active', '=', True)]}"
+                    />
                     <label for="name" class="oe_edit_only" />
                     <h1>
                         <field name="name" class="oe_inline" />

--- a/auth_api_key/views/res_config_settings.xml
+++ b/auth_api_key/views/res_config_settings.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2023 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+  <record id="res_config_settings_view_form" model="ir.ui.view">
+    <field name="name">res.config.settings.form.inherit</field>
+    <field name="model">res.config.settings</field>
+    <field name="inherit_id" ref="base_setup.res_config_settings_view_form" />
+    <field name="arch" type="xml">
+      <xpath expr="//div[@id='user_default_rights']" position="inside">
+
+        <div
+                    class="col-12 col-lg-6 o_setting_box"
+                    id="api_key_archive_with_user"
+                    groups="base.group_no_one"
+                >
+          <div class="o_setting_left_pane">
+            <field name="archived_user_disable_auth_api_key" />
+          </div>
+          <div class="o_setting_right_pane">
+            <label for="archived_user_disable_auth_api_key" />
+            <div class="text-muted">
+              Disable API key when archiving user
+            </div>
+          </div>
+        </div>
+
+      </xpath>
+
+    </field>
+  </record>
+
+</odoo>


### PR DESCRIPTION
An archived user should not have an active api key anymore. But to stay backward compatible the migration script will keep all key active.

This is to follow up on :
* https://github.com/OCA/server-auth/pull/396

ref.: cos-3714