### PR TITLE
[FIX]auth_saml: fix singleton error.

### DIFF
--- a/auth_saml/models/res_users.py
+++ b/auth_saml/models/res_users.py
@@ -136,7 +136,7 @@ class ResUser(models.Model):
         if not self.allow_saml_and_password():
             saml_users = self.filtered(
                 lambda user: user.sudo().saml_ids
-                and self.id not in self._saml_allowed_user_ids()
+                and user.id not in self._saml_allowed_user_ids()
                 and user.password
             )
             if saml_users:


### PR DESCRIPTION
Steps to reproduce:
- Configure SAML for 2 users.
- change the parameter auth_saml.allow_saml_uid_and_internal_password to False

CC: @vincent-hatakeyama 