### PR TITLE
Fix web.base.url

### DIFF
--- a/auth_saml/controllers/main.py
+++ b/auth_saml/controllers/main.py
@@ -170,7 +170,7 @@ class AuthSAMLController(http.Controller):
 
         provider = request.env["auth.saml.provider"].sudo().browse(provider_id)
         redirect_url = provider._get_auth_request(
-            self._get_saml_extra_relaystate(), request.httprequest.url_root.rstrip("/")
+            self._get_saml_extra_relaystate()
         )
         if not redirect_url:
             raise Exception(


### PR DESCRIPTION
Now is getting the current url of the request instead of using an environment variable of "web.base.url"

This causes an error when odoo is behind the proxy, and the proxy uses https, odoo thinks it is using http instead of https because it is behind the proxy, odoo sends to http instead https to serivce provider and cause fails auth

With this change now uses "web.base.url" correctly, and you can add manually your full domain including https

Note: maybe must be update to odoo 14 15 16