### PR TITLE
[16.0] auth_jwt: add cookie mode

### DIFF
--- a/auth_jwt/exceptions.py
+++ b/auth_jwt/exceptions.py
@@ -8,6 +8,10 @@ class UnauthorizedMissingAuthorizationHeader(Unauthorized):
     pass
 
 
+class UnauthorizedMissingCookie(Unauthorized):
+    pass
+
+
 class UnauthorizedMalformedAuthorizationHeader(Unauthorized):
     pass
 
@@ -44,3 +48,7 @@ class CompositeJwtError(Unauthorized):
                 for validator_name, error in self.errors.items()
             )
         )
+
+
+class UnauthorizedConfigurationError(Unauthorized):
+    pass

--- a/auth_jwt/exceptions.py
+++ b/auth_jwt/exceptions.py
@@ -36,7 +36,7 @@ class UnauthorizedPartnerNotFound(Unauthorized):
     pass
 
 
-class CompositeJwtError(Unauthorized):
+class UnauthorizedCompositeJwtError(Unauthorized):
     """Indicate that multiple errors occurred during JWT chain validation."""
 
     def __init__(self, errors):
@@ -50,5 +50,5 @@ class CompositeJwtError(Unauthorized):
         )
 
 
-class UnauthorizedConfigurationError(Unauthorized):
+class ConfigurationError(InternalServerError):
     pass

--- a/auth_jwt/models/auth_jwt_validator.py
+++ b/auth_jwt/models/auth_jwt_validator.py
@@ -126,6 +126,18 @@ class AuthJwtValidator(models.Model):
                         )
                     )
 
+    @api.constrains("cookie_enabled", "cookie_name")
+    def _check_cookie_name(self):
+        for rec in self:
+            if rec.cookie_enabled and not rec.cookie_name:
+                raise ValidationError(
+                    _(
+                        "A cookie name must be provided on JWT validator %s "
+                        "because it has cookie mode enabled."
+                    )
+                    % (rec.name,)
+                )
+
     @api.model
     def _get_validator_by_name_domain(self, validator_name):
         if validator_name:

--- a/auth_jwt/models/auth_jwt_validator.py
+++ b/auth_jwt/models/auth_jwt_validator.py
@@ -15,6 +15,7 @@ from odoo.exceptions import ValidationError
 
 from ..exceptions import (
     AmbiguousJwtValidator,
+    ConfigurationError,
     JwtValidatorNotFound,
     UnauthorizedInvalidToken,
     UnauthorizedPartnerNotFound,
@@ -272,3 +273,10 @@ class AuthJwtValidator(models.Model):
     def unlink(self):
         self._unregister_auth_method()
         return super().unlink()
+
+    def _get_jwt_cookie_secret(self):
+        secret = self.env["ir.config_parameter"].sudo().get_param("database.secret")
+        if not secret:
+            _logger.error("database.secret system parameter is not set.")
+            raise ConfigurationError()
+        return secret

--- a/auth_jwt/models/ir_http.py
+++ b/auth_jwt/models/ir_http.py
@@ -58,14 +58,6 @@ class IrHttpJwt(models.AbstractModel):
         return super()._authenticate(endpoint)
 
     @classmethod
-    def _get_jwt_cookie_secret(cls):
-        secret = request.env["ir.config_parameter"].sudo().get_param("database.secret")
-        if not secret:
-            _logger.error("database.secret system parameter is not set.")
-            raise ConfigurationError()
-        return secret
-
-    @classmethod
     def _get_jwt_payload(cls, validator):
         """Obtain and validate the JWT payload from the request authorization header or
         cookie."""
@@ -78,7 +70,7 @@ class IrHttpJwt(models.AbstractModel):
                 raise
             token = cls._get_cookie_token(validator.cookie_name)
             assert token
-            return validator._decode(token, secret=cls._get_jwt_cookie_secret())
+            return validator._decode(token, secret=validator._get_jwt_cookie_secret())
 
     @classmethod
     def _auth_method_jwt(cls, validator_name=None):
@@ -112,7 +104,7 @@ class IrHttpJwt(models.AbstractModel):
                 key=validator.cookie_name,
                 value=validator._encode(
                     payload,
-                    secret=cls._get_jwt_cookie_secret(),
+                    secret=validator._get_jwt_cookie_secret(),
                     expire=validator.cookie_max_age,
                 ),
                 max_age=validator.cookie_max_age,

--- a/auth_jwt/models/ir_http.py
+++ b/auth_jwt/models/ir_http.py
@@ -118,7 +118,13 @@ class IrHttpJwt(models.AbstractModel):
     @classmethod
     def _auth_method_public_or_jwt(cls, validator_name=None):
         if "HTTP_AUTHORIZATION" not in request.httprequest.environ:
-            return cls._auth_method_public()
+            env = api.Environment(request.cr, SUPERUSER_ID, {})
+            validator = env["auth.jwt.validator"]._get_validator_by_name(validator_name)
+            assert len(validator) == 1
+            if not validator.cookie_enabled or not request.httprequest.cookies.get(
+                validator.cookie_name
+            ):
+                return cls._auth_method_public()
         return cls._auth_method_jwt(validator_name)
 
     @classmethod

--- a/auth_jwt/readme/USAGE.rst
+++ b/auth_jwt/readme/USAGE.rst
@@ -24,7 +24,8 @@ The JWT validator can be configured with the following properties:
 In addition, the ``exp`` claim is validated to reject expired tokens.
 
 If the ``Authorization`` HTTP header is missing, malformed, or contains
-an invalid token, the request is rejected with a 401 (Unauthorized) code.
+an invalid token, the request is rejected with a 401 (Unauthorized) code,
+unless the cookie mode is enabled (see below).
 
 If the token is valid, the request executes with the configured user id. By
 default the user id selection strategy is ``static`` (i.e. the same for all
@@ -53,3 +54,11 @@ endpoints that need to work for anonymous users, but can be enhanced when an
 authenticated user is know. A typical use case is a "add to cart" endpoint that can work
 for anonymous users, but can be enhanced by binding the cart to a known customer when
 the authenticated user is known.
+
+You can enable a cookie mode on JWT validators. In this case, the JWT payload obtained
+from the ``Authorization`` header is returned as a Http-Only cookie. This mode is
+sometimes simpler for front-end applications which do not then need to store and protect
+the JWT token across requests and can simply rely on the cookie management mechanisms of
+browsers. When both the ``Authorization`` header and a cookie are provided, the cookie
+is ignored in order to let clients authenticate with a different user by providing a new
+JWT token.

--- a/auth_jwt/tests/test_auth_jwt.py
+++ b/auth_jwt/tests/test_auth_jwt.py
@@ -90,11 +90,13 @@ class TestAuthMethod(TransactionCase):
         )
 
     def test_missing_authorization_header(self):
+        self._create_validator("validator")
         with self._mock_request(authorization=None):
             with self.assertRaises(UnauthorizedMissingAuthorizationHeader):
-                self.env["ir.http"]._auth_method_jwt()
+                self.env["ir.http"]._auth_method_jwt(validator_name="validator")
 
     def test_malformed_authorization_header(self):
+        self._create_validator("validator")
         for authorization in (
             "a",
             "Bearer",
@@ -105,7 +107,7 @@ class TestAuthMethod(TransactionCase):
         ):
             with self._mock_request(authorization=authorization):
                 with self.assertRaises(UnauthorizedMalformedAuthorizationHeader):
-                    self.env["ir.http"]._auth_method_jwt()
+                    self.env["ir.http"]._auth_method_jwt(validator_name="validator")
 
     def test_auth_method_valid_token(self):
         self._create_validator("validator")

--- a/auth_jwt/tests/test_auth_jwt.py
+++ b/auth_jwt/tests/test_auth_jwt.py
@@ -15,8 +15,8 @@ from odoo.tools.misc import DotDict
 
 from ..exceptions import (
     AmbiguousJwtValidator,
-    CompositeJwtError,
     JwtValidatorNotFound,
+    UnauthorizedCompositeJwtError,
     UnauthorizedInvalidToken,
     UnauthorizedMalformedAuthorizationHeader,
     UnauthorizedMissingAuthorizationHeader,
@@ -196,7 +196,7 @@ class TestAuthMethod(TransactionCase):
 
         authorization = "Bearer " + self._create_token()
         with self._mock_request(authorization=authorization):
-            with self.assertRaises(CompositeJwtError) as composite_error:
+            with self.assertRaises(UnauthorizedCompositeJwtError) as composite_error:
                 self.env["ir.http"]._auth_method_jwt_validator()
             self.assertEqual(
                 str(composite_error.exception),

--- a/auth_jwt/views/auth_jwt_validator_views.xml
+++ b/auth_jwt/views/auth_jwt_validator_views.xml
@@ -7,12 +7,12 @@
             <form string="arch">
                 <sheet>
                     <group col="4">
-                        <group colspan="2">
+                        <group colspan="2" string="General">
                             <field name="name" />
-                            <field name="audience" />
                             <field name="next_validator_id" />
                         </group>
-                        <group colspan="2">
+                        <group colspan="2" string="Token validation">
+                            <field name="audience" />
                             <field name="issuer" />
                             <field name="signature_type" />
                             <field
@@ -41,7 +41,7 @@
                                     'required': [('signature_type', '=', 'public_key')]}"
                             />
                         </group>
-                        <group colspan="2">
+                        <group colspan="2" string="User">
                             <field name="user_id_strategy" />
                             <field
                                 name="static_user_id"
@@ -49,9 +49,25 @@
                                         'required': [('user_id_strategy', '=', 'static')]}"
                             />
                         </group>
-                        <group colspan="2">
+                        <group colspan="2" string="Partner">
                             <field name="partner_id_strategy" />
                             <field name="partner_id_required" />
+                        </group>
+                        <group colspan="2" string="Cookie">
+                            <field name="cookie_enabled" />
+                            <field
+                                name="cookie_name"
+                                attrs="{'required': [('cookie_enabled', '=', True)],
+                                        'invisible': [('cookie_enabled', '=', False)]}"
+                            />
+                            <field
+                                name="cookie_path"
+                                attrs="{'invisible': [('cookie_enabled', '=', False)]}"
+                            />
+                            <field
+                                name="cookie_max_age"
+                                attrs="{'invisible': [('cookie_enabled', '=', False)]}"
+                            />
                         </group>
                     </group>
                 </sheet>

--- a/auth_jwt_demo/controllers/main.py
+++ b/auth_jwt_demo/controllers/main.py
@@ -18,9 +18,25 @@ class JWTTestController(Controller):
     )
     def whoami(self):
         data = {}
-        if request.jwt_partner_id:
+        if getattr(request, "jwt_partner_id", None):
             partner = request.env["res.partner"].browse(request.jwt_partner_id)
             data.update(name=partner.name, email=partner.email, uid=request.env.uid)
+        return Response(json.dumps(data), content_type="application/json", status=200)
+
+    @route(
+        "/auth_jwt_demo/whoami-public-or-jwt",
+        type="http",
+        auth="public_or_jwt_demo",
+        csrf=False,
+        cors="*",
+        save_session=False,
+        methods=["GET", "OPTIONS"],
+    )
+    def whoami_public_or_jwt(self):
+        data = {"uid": request.env.uid}
+        if getattr(request, "jwt_partner_id", None):
+            partner = request.env["res.partner"].browse(request.jwt_partner_id)
+            data.update(name=partner.name, email=partner.email)
         return Response(json.dumps(data), content_type="application/json", status=200)
 
     @route(
@@ -33,10 +49,26 @@ class JWTTestController(Controller):
         methods=["GET", "OPTIONS"],
     )
     def whoami_cookie(self):
-        data = {}
-        if request.jwt_partner_id:
+        data = {"uid": request.env.uid}
+        if getattr(request, "jwt_partner_id", None):
             partner = request.env["res.partner"].browse(request.jwt_partner_id)
-            data.update(name=partner.name, email=partner.email, uid=request.env.uid)
+            data.update(name=partner.name, email=partner.email)
+        return Response(json.dumps(data), content_type="application/json", status=200)
+
+    @route(
+        "/auth_jwt_demo_cookie/whoami-public-or-jwt",
+        type="http",
+        auth="public_or_jwt_demo_cookie",
+        csrf=False,
+        cors="*",
+        save_session=False,
+        methods=["GET", "OPTIONS"],
+    )
+    def whoami_cookie_public_or_jwt(self):
+        data = {"uid": request.env.uid}
+        if getattr(request, "jwt_partner_id", None):
+            partner = request.env["res.partner"].browse(request.jwt_partner_id)
+            data.update(name=partner.name, email=partner.email)
         return Response(json.dumps(data), content_type="application/json", status=200)
 
     @route(
@@ -55,7 +87,7 @@ class JWTTestController(Controller):
         identity provider in tests/keycloak.
         """
         data = {}
-        if request.jwt_partner_id:
+        if getattr(request, "jwt_partner_id", None):
             partner = request.env["res.partner"].browse(request.jwt_partner_id)
             data.update(name=partner.name, email=partner.email)
         return Response(json.dumps(data), content_type="application/json", status=200)
@@ -75,11 +107,11 @@ class JWTTestController(Controller):
         You can play with this using the browser app in tests/spa and the
         identity provider in tests/keycloak.
         """
-        data = {}
-        if hasattr(request, "jwt_partner_id") and request.jwt_partner_id:
+        data = {"uid": request.env.uid}
+        if getattr(request, "jwt_partner_id", None):
             partner = request.env["res.partner"].browse(request.jwt_partner_id)
-            data.update(name=partner.name, email=partner.email, uid=request.env.uid)
+            data.update(name=partner.name, email=partner.email)
         else:
             # public
-            data.update(name="Anonymous", uid=request.env.uid)
+            data.update(name="Anonymous")
         return Response(json.dumps(data), content_type="application/json", status=200)

--- a/auth_jwt_demo/controllers/main.py
+++ b/auth_jwt_demo/controllers/main.py
@@ -24,6 +24,22 @@ class JWTTestController(Controller):
         return Response(json.dumps(data), content_type="application/json", status=200)
 
     @route(
+        "/auth_jwt_demo_cookie/whoami",
+        type="http",
+        auth="jwt_demo_cookie",
+        csrf=False,
+        cors="*",
+        save_session=False,
+        methods=["GET", "OPTIONS"],
+    )
+    def whoami_cookie(self):
+        data = {}
+        if request.jwt_partner_id:
+            partner = request.env["res.partner"].browse(request.jwt_partner_id)
+            data.update(name=partner.name, email=partner.email, uid=request.env.uid)
+        return Response(json.dumps(data), content_type="application/json", status=200)
+
+    @route(
         "/auth_jwt_demo/keycloak/whoami",
         type="http",
         auth="jwt_demo_keycloak",

--- a/auth_jwt_demo/demo/auth_jwt_validator.xml
+++ b/auth_jwt_demo/demo/auth_jwt_validator.xml
@@ -11,6 +11,20 @@
         <field name="partner_id_strategy">email</field>
         <field name="partner_id_required" eval="False" />
     </record>
+    <record id="demo_cookie_validator" model="auth.jwt.validator">
+        <field name="name">demo_cookie</field>
+        <field name="audience">auth_jwt_test_api</field>
+        <field name="issuer">theissuer</field>
+        <field name="signature_type">secret</field>
+        <field name="secret_algorithm">HS256</field>
+        <field name="secret_key">thesecret</field>
+        <field name="user_id_strategy">static</field>
+        <field name="static_user_id" ref="base.user_demo" />
+        <field name="partner_id_strategy">email</field>
+        <field name="partner_id_required" eval="False" />
+        <field name="cookie_enabled" eval="True" />
+        <field name="cookie_name">demo_auth</field>
+    </record>
     <record id="demo_keycloak_validator" model="auth.jwt.validator">
         <field name="name">demo_keycloak</field>
         <field name="audience">auth_jwt_test_api</field>

--- a/auth_jwt_demo/tests/test_auth_jwt_demo.py
+++ b/auth_jwt_demo/tests/test_auth_jwt_demo.py
@@ -15,6 +15,9 @@ class TestRegisterHook(tests.HttpCase):
         self.assertEqual(len(validator), 1)
         self.assertTrue(hasattr(self.env["ir.http"].__class__, "_auth_method_jwt_demo"))
 
+
+@tests.tagged("post_install", "-at_install")
+class TestEndToEnd(tests.HttpCase):
     def _get_token(self, aud=None, email=None):
         validator = self.env["auth.jwt.validator"].search([("name", "=", "demo")])
         payload = {
@@ -103,7 +106,8 @@ class TestRegisterHook(tests.HttpCase):
         partner = self.env["res.users"].search([("email", "!=", False)], limit=1)
         token = self._get_token(email=partner.email)
         resp = self.url_open(
-            "/auth_jwt_demo_cookie/whoami-public-or-jwt", headers={"Authorization": token}
+            "/auth_jwt_demo_cookie/whoami-public-or-jwt",
+            headers={"Authorization": token},
         )
         resp.raise_for_status()
         whoami = resp.json()

--- a/auth_jwt_demo/tests/test_auth_jwt_demo.py
+++ b/auth_jwt_demo/tests/test_auth_jwt_demo.py
@@ -79,6 +79,56 @@ class TestRegisterHook(tests.HttpCase):
 
     def test_public(self):
         """A end-to-end test for anonymous/public access."""
+        resp = self.url_open("/auth_jwt_demo/whoami-public-or-jwt")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["uid"], self.ref("base.public_user"))
+        # now try with a token
+        partner = self.env["res.users"].search([("email", "!=", False)], limit=1)
+        token = self._get_token(email=partner.email)
+        resp = self.url_open(
+            "/auth_jwt_demo/whoami-public-or-jwt", headers={"Authorization": token}
+        )
+        resp.raise_for_status()
+        whoami = resp.json()
+        self.assertEqual(whoami.get("name"), partner.name)
+        self.assertEqual(whoami.get("email"), partner.email)
+        self.assertEqual(whoami.get("uid"), self.env.ref("base.user_demo").id)
+
+    def test_public_cookie_mode(self):
+        """A end-to-end test for anonymous/public access with cookie."""
+        resp = self.url_open("/auth_jwt_demo_cookie/whoami-public-or-jwt")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["uid"], self.ref("base.public_user"))
+        # now try with a token
+        partner = self.env["res.users"].search([("email", "!=", False)], limit=1)
+        token = self._get_token(email=partner.email)
+        resp = self.url_open(
+            "/auth_jwt_demo_cookie/whoami-public-or-jwt", headers={"Authorization": token}
+        )
+        resp.raise_for_status()
+        whoami = resp.json()
+        self.assertEqual(whoami.get("name"), partner.name)
+        self.assertEqual(whoami.get("email"), partner.email)
+        self.assertEqual(whoami.get("uid"), self.env.ref("base.user_demo").id)
+        # now try with the cookie
+        cookie = resp.cookies.get("demo_auth")
+        self.assertTrue(cookie)
+        partner = self.env["res.users"].search([("email", "!=", False)], limit=1)
+        token = self._get_token(email=partner.email)
+        resp = self.url_open(
+            "/auth_jwt_demo_cookie/whoami-public-or-jwt",
+            headers={"Cookie": f"demo_auth={cookie}"},
+        )
+        resp.raise_for_status()
+        whoami = resp.json()
+        self.assertEqual(whoami.get("name"), partner.name)
+        self.assertEqual(whoami.get("email"), partner.email)
+        self.assertEqual(whoami.get("uid"), self.env.ref("base.user_demo").id)
+        cookie = resp.cookies.get("demo_auth")
+        self.assertTrue(cookie)
+
+    def test_public_keyloak(self):
+        """A end-to-end test for anonymous/public access."""
         resp = self.url_open("/auth_jwt_demo/keycloak/whoami-public-or-jwt")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["uid"], self.ref("base.public_user"))

--- a/auth_jwt_demo/tests/test_auth_jwt_demo.py
+++ b/auth_jwt_demo/tests/test_auth_jwt_demo.py
@@ -45,6 +45,32 @@ class TestRegisterHook(tests.HttpCase):
         resp = self.url_open("/auth_jwt_demo/whoami", headers={"Authorization": token})
         self.assertEqual(resp.status_code, 401)
 
+    def test_whoami_cookie(self):
+        """A end-to-end test with positive authentication and cookie."""
+        partner = self.env["res.users"].search([("email", "!=", False)])[0]
+        token = self._get_token(email=partner.email)
+        resp = self.url_open(
+            "/auth_jwt_demo_cookie/whoami", headers={"Authorization": token}
+        )
+        resp.raise_for_status()
+        whoami = resp.json()
+        self.assertEqual(whoami.get("name"), partner.name)
+        self.assertEqual(whoami.get("email"), partner.email)
+        self.assertEqual(whoami.get("uid"), self.env.ref("base.user_demo").id)
+        cookie = resp.cookies.get("demo_auth")
+        self.assertTrue(cookie)
+        # Try again with the cookie.
+        resp = self.url_open(
+            "/auth_jwt_demo_cookie/whoami", headers={"Cookie": f"demo_auth={cookie}"}
+        )
+        resp.raise_for_status()
+        whoami = resp.json()
+        self.assertEqual(whoami.get("name"), partner.name)
+        self.assertEqual(whoami.get("email"), partner.email)
+        self.assertEqual(whoami.get("uid"), self.env.ref("base.user_demo").id)
+        cookie = resp.cookies.get("demo_auth")
+        self.assertTrue(cookie)
+
     def test_forbidden(self):
         """A end-to-end test with negative authentication."""
         token = self._get_token(aud="invalid")


### PR DESCRIPTION
Add a cookie mode on JWT validators. In this case, the JWT payload obtained
from the ``Authorization`` header is returned as a Http-Only cookie. This mode is
sometimes simpler for front-end applications which do not then need to store and protect
the JWT token across requests and can simply rely on the cookie management mechanisms of
browsers. When both the ``Authorization`` header and a cookie are provided, the cookie
is ignored in order to let clients authenticate with a different user by providing a new
JWT token.
