### PR TITLE
[14.0][FIX] vault: version not set when migrate from 13.0

### DIFF
--- a/vault/migrations/14.0.1.8.0/post-migration.py
+++ b/vault/migrations/14.0.1.8.0/post-migration.py
@@ -1,0 +1,14 @@
+# Copyright 2023 Tecnativa - Carlos Roca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+from openupgradelib import openupgrade
+
+
+def set_users_key_version(env):
+    openupgrade.logged_query(env.cr, "UPDATE res_users_key SET version = 1")
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    set_users_key_version(env)


### PR DESCRIPTION
When we migrate from 13.0 the values of the version field take null value, this causes that when we introduce the user keys to see the vaults, the system throws the following error:
![image](https://github.com/OCA/server-auth/assets/35952655/effa5ead-cc31-482d-859e-cb0a727688bf)

cc @Tecnativa TT43889

ping @pedrobaeza @fkantelberg