### PR TITLE
[15.0][FIX] vault, vault_share: Error on test

### DIFF
--- a/vault/tests/test_controller.py
+++ b/vault/tests/test_controller.py
@@ -55,7 +55,7 @@ class TestController(TransactionCase):
             return context
 
         with MockRequest(self.env) as request_mock:
-            request_mock.render.side_effect = return_context
+            request_mock.render = return_context
             response = self.controller.vault_inbox("")
             self.assertIn("error", response)
 

--- a/vault_share/tests/test_share.py
+++ b/vault_share/tests/test_share.py
@@ -59,7 +59,7 @@ class TestShare(TransactionCase):
             return context
 
         with MockRequest(self.env) as request_mock:
-            request_mock.render.side_effect = return_context
+            request_mock.render = return_context
             controller = main.Controller()
 
             response = controller.vault_share("")


### PR DESCRIPTION
With the changes introduced on https://github.com/odoo/odoo/commit/a251b14f017b35899663d30a1b38cb75a41cdb1b#diff-99de14b6e0a411718ac3adaaf779395155841c7ca9d95fa258369656dae63d18 the tests of vault and vault_share are failing.

cc @Tecnativa 

@fkantelberg please, can you review this. I'm not sure if this solution is the correct one, but we need to solve this.

Sorry for the inconvenience