### PR TITLE
[15.0][FIX] vault: Error thrown when attempting to remove a right from a vault with more than 2 defined rigths.

### DIFF
--- a/vault/models/res_users.py
+++ b/vault/models/res_users.py
@@ -27,7 +27,7 @@ class ResUsers(models.Model):
     @api.depends("keys", "keys.current")
     def _compute_active_key(self):
         for rec in self:
-            keys = rec.keys.filtered("current")
+            keys = rec.sudo().keys.filtered("current")
             rec.active_key = keys[0] if keys else None
 
     @api.depends("inbox_token")


### PR DESCRIPTION
Before the patch, an error would occur when clicking on OK after warning about key re-encryption. This is because the public_key field of user rights other than the one initiating the deletion is not available. You can see the error on next gif:
![Error_vault](https://github.com/OCA/server-auth/assets/35952655/2a4a9f14-d64c-4801-986f-a52271d4636e)

After the patch, the public_key field is computed, and therefore, when re-encrypting, the error no longer occurs. In the following gif, you can see how the process is completed:
![Vault_deleted](https://github.com/OCA/server-auth/assets/35952655/8e436a6f-fd00-4f37-bc5a-fcb702647763)

cc @Tecnativa TT44079

ping @fkantelberg @pedrobaeza 