### PR TITLE
[14.0] auth_api_key: allow to update api key from form view and hide …

### DIFF
--- a/auth_api_key/views/auth_api_key.xml
+++ b/auth_api_key/views/auth_api_key.xml
@@ -6,7 +6,7 @@
         <field name="name">auth.api.key.form (in auth_api_key)</field>
         <field name="model">auth.api.key</field>
         <field name="arch" type="xml">
-            <form create="false" edit="false">
+            <form>
                 <sheet>
                   <field name="active" invisible="1" />
                   <widget
@@ -21,7 +21,7 @@
                     </h1>
                     <group name="config" colspan="4" col="4">
                         <field name="user_id" colspan="4" />
-                        <field name="key" colspan="4" />
+                        <field name="key" colspan="4" password="True" />
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
…keys in UI

While using with server `auth_api_key_server_env` and `server_environment_data_encryption` modules it makes hard to edit values for different environments.

Also I fill it's better practice to hide the key value on user interface so I've had the `password="True"` (I'm not considering this as security improvement but worth of it)
