### PR TITLE
[14.0][FIX] auth_session_timeout: session does not expire on page refresh

### DIFF
--- a/auth_session_timeout/models/ir_http.py
+++ b/auth_session_timeout/models/ir_http.py
@@ -11,6 +11,6 @@ class IrHttp(models.AbstractModel):
     def _authenticate(cls, endpoint):
         res = super(IrHttp, cls)._authenticate(endpoint=endpoint)
         auth_method = endpoint.routing["auth"]
-        if auth_method == "user" and request and request.env and request.env.user:
+        if auth_method == "user" and request and request.session and request.session.uid:
             request.env.user._auth_timeout_check()
         return res

--- a/auth_session_timeout/models/ir_http.py
+++ b/auth_session_timeout/models/ir_http.py
@@ -10,7 +10,11 @@ class IrHttp(models.AbstractModel):
     @classmethod
     def _authenticate(cls, endpoint):
         res = super(IrHttp, cls)._authenticate(endpoint=endpoint)
-        auth_method = endpoint.routing["auth"]
-        if auth_method == "user" and request and request.session and request.session.uid:
+        if (
+            request
+            and request.session
+            and request.session.uid
+            and not request.env["res.users"].browse(request.session.uid)._is_public()
+        ):
             request.env.user._auth_timeout_check()
         return res


### PR DESCRIPTION
We ran into a problem whereby:

- Timeout is set to 5 seconds
- Regular RPC calls cause a session timeout
- Page refresh does not trigger session timeout

This is a regression since https://github.com/OCA/server-auth/pull/269, because when page is refreshed with F5, it calls `/web`, which is a public route, so it does not trigger the session check but it does trigger [session save](https://github.com/OCA/OCB/blob/16.0/odoo/http.py#L1499), which updates the file mtime. When a second HTTP call makes the check takes place, the session is seen as not expired, and this can repeat indefinitely.

An earlier incarnation of this bug made us come up with [this patch](https://github.com/OCA/server-auth/pull/474) - before this patch, it could happen that `request.env.user` was not filled so the session timeout check was not done, but the session was saved, so the same conundrum could happen.

This PR contains:

- A forward port of the latter patch
- A fix for the new problem, in which we don't check for `auth_method != 'user'`, but for the session uid to be the public user. If it's the public user, the session won't expire.

@dreispt @lmignon @sbidoul 