### PR TITLE
[15.0][FIX] vault: Error when reencripting

### DIFF
--- a/vault/models/vault.py
+++ b/vault/models/vault.py
@@ -162,3 +162,12 @@ class Vault(models.Model):
             "target": "new",
             "context": {"default_vault_id": self.id},
         }
+
+    @api.model
+    def vault_store_related_changes(self, changes):
+        """Save changes related to some change on vault. Example: Remove some
+        vault_right from a specific vault.
+        """
+        for change in changes:
+            record = self.env[change["model"]].sudo().browse(change["id"])
+            record.write(change["changes"])

--- a/vault/static/src/common/utils.esm.js
+++ b/vault/static/src/common/utils.esm.js
@@ -418,10 +418,10 @@ async function sym_decrypt(key, crypted, iv) {
 
         console.error("Invalid data hash");
         // Wrong hash
-        return null;
+        return "";
     } catch (err) {
         console.error(err);
-        return null;
+        return "";
     }
 }
 

--- a/vault/static/src/legacy/vault_controller.js
+++ b/vault/static/src/legacy/vault_controller.js
@@ -300,6 +300,11 @@ odoo.define("vault.controller", function (require) {
                     ),
                     {
                         confirm_callback: async function () {
+                            const buttons = this.buttons;
+                            _.each(buttons, function (buttonToDisable) {
+                                buttonToDisable.disabled = true;
+                            });
+                            this.set_buttons(buttons);
                             await self._deleteVaultRight(
                                 record,
                                 changes.right_ids,


### PR DESCRIPTION
To reproduce the error, the steps would be:
1. Access a Vault with a significant number of records, and some of them have null-valued keys.
2. Remove a permission from the vault and re-encrypt the keys.
3. When you save, an error will be thrown due to a required field being empty, and any keys that haven't been saved will be lost.

With the changes applied in this patch, the aforementioned error no longer occurs, and the keys that are in an inconsistent state no longer cause the others to become corrupted. In addition to fixing this, we have added the feature to disable the re-encryption assistant buttons to avoid the impression that nothing is happening.

cc @Tecnativa TT44183

Please @fkantelberg review this. This is the only option that has occurred to me to solve the encryption problem when there is any key in an inconsistent state in the Vault. If you believe there might be a better solution, it would be greatly appreciated.