### PR TITLE
[FIX] vault: Vault re-encryption in a single transaction

### DIFF
--- a/vault/controllers/main.py
+++ b/vault/controllers/main.py
@@ -126,3 +126,21 @@ class Controller(http.Controller):
 
             if isinstance(master_key, str):
                 right.sudo().key = master_key
+
+    @http.route("/vault/replace", auth="user", type="json")
+    def vault_replace(self, data):
+        """Replace the master keys and values within a single transaction"""
+        if not isinstance(data, list):
+            return
+
+        vault = request.env["vault"].with_context(vault_skip_log=True)
+        for changes in data:
+            record = vault.env[changes["model"]].browse(changes["id"])
+            vault |= record.vault_id
+            if record._name in ("vault.field", "vault.file"):
+                record.write({k: v for k, v in changes.items() if k in ["iv", "value"]})
+            elif record._name == "vault.right":
+                record.write({k: v for k, v in changes.items() if k in ["key"]})
+
+        for v in vault:
+            v._log_entry("Replaced the keys", "info")

--- a/vault/controllers/main.py
+++ b/vault/controllers/main.py
@@ -144,3 +144,5 @@ class Controller(http.Controller):
 
         for v in vault:
             v._log_entry("Replaced the keys", "info")
+
+        vault.sudo().write({"reencrypt_required": False})

--- a/vault/models/abstract_vault_field.py
+++ b/vault/models/abstract_vault_field.py
@@ -13,6 +13,7 @@ class AbstractVaultField(models.AbstractModel):
     _description = _("Abstract model to implement basic fields for encryption")
 
     entry_id = fields.Many2one("vault.entry", ondelete="cascade", required=True)
+    entry_name = fields.Char(related="entry_id.complete_name")
     vault_id = fields.Many2one(related="entry_id.vault_id")
     master_key = fields.Char(compute="_compute_master_key", store=False)
 

--- a/vault/models/abstract_vault_field.py
+++ b/vault/models/abstract_vault_field.py
@@ -33,6 +33,9 @@ class AbstractVaultField(models.AbstractModel):
 
     def log_change(self, action):
         self.ensure_one()
+        if self.env.context.get("vault_skip_log"):
+            return
+
         self.entry_id.log_info(
             f"{action} value {self.name} of {self.entry_id.complete_name} "
             f"by {self.env.user.display_name}"

--- a/vault/models/vault.py
+++ b/vault/models/vault.py
@@ -32,6 +32,7 @@ class Vault(models.Model):
     field_ids = fields.One2many("vault.field", "vault_id", "Fields")
     file_ids = fields.One2many("vault.file", "vault_id", "Files")
     log_ids = fields.One2many("vault.log", "vault_id", "Log", readonly=True)
+    reencrypt_required = fields.Boolean(default=False)
 
     # Access control
     perm_user = fields.Many2one("res.users", compute="_compute_access", store=False)

--- a/vault/models/vault_entry.py
+++ b/vault/models/vault_entry.py
@@ -46,7 +46,7 @@ class VaultEntry(models.Model):
         readonly=True,
         recursive=True,
     )
-    uuid = fields.Char(default=lambda self: uuid4(), required=True)
+    uuid = fields.Char(default=lambda self: uuid4(), required=True, copy=False)
     name = fields.Char(required=True)
     url = fields.Char()
     note = fields.Text()
@@ -98,6 +98,25 @@ class VaultEntry(models.Model):
             domain=domain, fields=fields, offset=offset, limit=limit, order=order
         )
 
+    def copy_data(self, default=None):
+        self.ensure_one()
+
+        if default is None:
+            default = {}
+
+        if "name" not in default:
+            default["name"] = _("%s (copy)", self.name)
+
+        if "field_ids" not in default:
+            default["field_ids"] = [
+                (0, 0, field.copy_data()[0]) for field in self.field_ids
+            ]
+        if "file_ids" not in default:
+            default["file_ids"] = [
+                (0, 0, field.copy_data()[0]) for field in self.file_ids
+            ]
+        return super().copy_data(default)
+
     @api.depends("name", "complete_name")
     def _compute_display_name(self):
         if not self.env.context.get("entry_short_name", False):
@@ -122,6 +141,9 @@ class VaultEntry(models.Model):
 
     def log_change(self, action):
         self.ensure_one()
+        if self.env.context.get("vault_skip_log"):
+            return
+
         self.log_info(
             _("%(action)s entry %(name)s by %(user)s")
             % {

--- a/vault/models/vault_right.py
+++ b/vault/models/vault_right.py
@@ -106,5 +106,6 @@ class VaultRight(models.Model):
     def unlink(self):
         for rec in self:
             rec.vault_id.log_info(f"Removed user {self.user_id.display_name}")
+            rec.vault_id.reencrypt_required = True
 
         return super().unlink()

--- a/vault/static/src/legacy/vault_controller.js
+++ b/vault/static/src/legacy/vault_controller.js
@@ -15,6 +15,11 @@ odoo.define("vault.controller", function (require) {
     var _t = core._t;
 
     FormController.include({
+        events: _.extend({}, FormController.prototype.events, {
+            "click [name='vault_reencrypt']": "_clickReencryptVault",
+            "click [name='vault_verify']": "_clickVerifyVault",
+        }),
+
         /**
          * Re-encrypt the key if the user is getting selected
          *
@@ -187,65 +192,42 @@ odoo.define("vault.controller", function (require) {
             }
         },
 
+        _clickReencryptVault: async function () {
+            await this._reencryptVault(false, true);
+        },
+
+        _clickVerifyVault: async function () {
+            await this._reencryptVault(true, false);
+        },
+
         /**
          * Handle the deletion of a vault.right field in the vault view properly by
          * generating a new master key and re-encrypting everything in the vault to
          * deny any future access to the vault.
          *
          * @private
-         * @param {Object} record
-         * @param {Object} changes
-         * @param {Object} options
+         * @param {Boolean} verify
+         * @param {Boolean} force
          */
-        _deleteVaultRight: async function (record, changes) {
+        _reencryptVault: async function (verify = false, force = false) {
+            const record = this.model.get(this.handle);
+
+            await vault._ensure_keys();
+
             const self = this;
             const master_key = await utils.generate_key();
             const current_key = await vault.unwrap(record.data.master_key);
 
-            // We only need to re-encrypt once per iteration
-            if (this._vault_changes) return;
-
             // This stores the additional changes made to rights, fields, and files
-            this._vault_changes = [];
+            const changes = [];
+            const problems = [];
 
-            // Convert the datapoint IDs to database IDs because we are loading
-            const deleted = [];
-            for (const right_id of changes.ids) {
-                const rec = await this.model.get(right_id, {raw: true});
-                deleted.push(rec.res_id);
-            }
-
-            // Update the rights. Load without limit
-            const right_handle = await this.model.load({
-                domain: [["vault_id", "=", record.res_id]],
-                fields: ["key"],
-                modelName: "vault.right",
-                limit: 0,
-                type: "list",
-            });
-
-            const rights = await this.model.get(right_handle, {raw: true});
-            for (const right of rights.data) {
-                if (deleted.indexOf(right.res_id) < 0) {
-                    const key = await vault.wrap_with(
-                        master_key,
-                        right.data.public_key
-                    );
-
-                    this._vault_changes.push({
-                        id: right.res_id,
-                        model: "vault.right",
-                        key: key,
-                    });
-                }
-            }
-
-            async function reencrypt(model) {
+            async function reencrypt(model, type) {
                 // Load the entire data from the database
                 const handle = await self.model.load({
                     context: {vault_reencrypt: true},
                     domain: [["vault_id", "=", record.res_id]],
-                    fields: ["iv", "value"],
+                    fields: ["iv", "value", "name", "entry_name"],
                     modelName: model,
                     limit: 0,
                     type: "list",
@@ -257,10 +239,22 @@ odoo.define("vault.controller", function (require) {
 
                     const d = rec.data;
                     const val = await utils.sym_decrypt(current_key, d.value, d.iv);
+                    if (val === null) {
+                        problems.push(
+                            _.str.sprintf(
+                                _t("%s '%s' of entry '%s'"),
+                                type,
+                                d.name,
+                                d.entry_name
+                            )
+                        );
+                        continue;
+                    }
+
                     const iv = utils.generate_iv_base64();
                     const encrypted = await utils.sym_encrypt(master_key, val, iv);
 
-                    self._vault_changes.push({
+                    changes.push({
                         id: rec.res_id,
                         model: model,
                         value: encrypted,
@@ -269,9 +263,53 @@ odoo.define("vault.controller", function (require) {
                 }
             }
 
-            // Re-encrypt vault.field and vault.file
-            await reencrypt("vault.field");
-            await reencrypt("vault.file");
+            framework.blockUI();
+            try {
+                // Update the rights. Load without limit
+                const right_handle = await this.model.load({
+                    domain: [["vault_id", "=", record.res_id]],
+                    fields: ["key"],
+                    modelName: "vault.right",
+                    limit: 0,
+                    type: "list",
+                });
+
+                const rights = await this.model.get(right_handle, {raw: true});
+                for (const right of rights.data) {
+                    const key = await vault.wrap_with(
+                        master_key,
+                        right.data.public_key
+                    );
+
+                    changes.push({
+                        id: right.res_id,
+                        model: "vault.right",
+                        key: key,
+                    });
+                }
+
+                // Re-encrypt vault.field and vault.file
+                await reencrypt("vault.field", "Field");
+                await reencrypt("vault.file", "File");
+
+                if (problems && !force) {
+                    framework.unblockUI();
+
+                    Dialog.alert(self, "", {
+                        title: _t("The following entries are broken:"),
+                        $content: $("<div/>").html(problems.join("<br>\n")),
+                    });
+                }
+
+                if (!verify) {
+                    await this._rpc({
+                        route: "/vault/replace",
+                        params: {data: changes},
+                    });
+                }
+            } finally {
+                framework.unblockUI();
+            }
         },
 
         /**
@@ -291,36 +329,6 @@ odoo.define("vault.controller", function (require) {
 
             if (changes.right_ids && changes.right_ids.operation === "UPDATE")
                 await this._changedVaultRightUser(record, changes.right_ids, options);
-
-            if (changes.right_ids && changes.right_ids.operation === "DELETE") {
-                const self = this;
-
-                if (this._vault_changes) return;
-
-                Dialog.confirm(
-                    self,
-                    _t(
-                        "This will re-encrypt everything in the vault. Do you want to proceed?"
-                    ),
-                    {
-                        confirm_callback: async function () {
-                            // Ensure that the keys are decrypted
-                            await vault._ensure_keys();
-
-                            try {
-                                framework.blockUI();
-                                await self._deleteVaultRight(
-                                    record,
-                                    changes.right_ids,
-                                    options
-                                );
-                            } finally {
-                                framework.unblockUI();
-                            }
-                        },
-                    }
-                );
-            }
         },
 
         /**
@@ -375,42 +383,6 @@ odoo.define("vault.controller", function (require) {
                 await this._applyChangesImportWizard(record, changes, options);
 
             return result;
-        },
-
-        /**
-         * Check if there are additional changes made which needs to be pushed to
-         * the database
-         *
-         * @override
-         * @param {String} recordID
-         * @param {Object} options
-         */
-        saveRecord: async function () {
-            const res = await this._super(...arguments);
-
-            if (this._vault_changes && this.modelName === "vault") {
-                await this._rpc({
-                    route: "/vault/replace",
-                    params: {data: this._vault_changes},
-                });
-
-                this._vault_changes = [];
-            }
-
-            return res;
-        },
-
-        /**
-         * Invalidate the additional vault changes
-         *
-         * @override
-         */
-        _discardChanges: async function () {
-            const res = await this._super(...arguments);
-            if (this.modelName !== "vault") return res;
-
-            this._vault_changes = [];
-            return res;
         },
     });
 });

--- a/vault/static/src/legacy/vault_controller.js
+++ b/vault/static/src/legacy/vault_controller.js
@@ -304,6 +304,9 @@ odoo.define("vault.controller", function (require) {
                     ),
                     {
                         confirm_callback: async function () {
+                            // Ensure that the keys are decrypted
+                            await vault._ensure_keys();
+
                             try {
                                 framework.blockUI();
                                 await self._deleteVaultRight(

--- a/vault/tests/test_controller.py
+++ b/vault/tests/test_controller.py
@@ -125,6 +125,39 @@ class TestController(TransactionCase):
             self.assertEqual(response["public_key"], self.key.public)
 
     @mute_logger("odoo.sql_db")
+    def test_vault_replace(self):
+        with MockRequest(self.env):
+            vault = self.env["vault"].create({"name": "Vault"})
+            right = vault.right_ids[:1]
+            entry = self.env["vault.entry"].create(
+                {"name": "Test Entry", "vault_id": vault.id}
+            )
+            field = self.env["vault.field"].create(
+                {"entry_id": entry.id, "name": "Test", "value": "hello"}
+            )
+            file = self.env["vault.file"].create(
+                {"entry_id": entry.id, "name": "Test", "value": b"hello"}
+            )
+            right.write({"key": "invalid"})
+
+            self.controller.vault_replace(None)
+            self.assertEqual(field.value, "hello")
+            self.assertEqual(file.value, b"hello")
+
+            vault.reencrypt_required = True
+            self.controller.vault_replace(
+                [
+                    {"model": field._name, "id": field.id, "value": "test"},
+                    {"model": file._name, "id": file.id, "value": "test"},
+                    {"model": right._name, "id": right.id, "key": "changed"},
+                ]
+            )
+            self.assertEqual(field.value, "test")
+            self.assertEqual(file.value, b"test")
+            self.assertEqual(right.key, "changed")
+            self.assertFalse(vault.reencrypt_required)
+
+    @mute_logger("odoo.sql_db")
     def test_vault_store(
         self,
     ):

--- a/vault/tests/test_rights.py
+++ b/vault/tests/test_rights.py
@@ -24,6 +24,19 @@ class TestAccessRights(TransactionCase):
         )
         self.vault.right_ids.write({"key": "Owner"})
 
+    def test_vault_reencrypt(self):
+        right = self.env["vault.right"].create(
+            {
+                "vault_id": self.vault.id,
+                "user_id": self.user.id,
+                "perm_create": False,
+            }
+        )
+
+        assert not self.vault.reencrypt_required
+        right.unlink()
+        assert self.vault.reencrypt_required
+
     def test_public_key(self):
         key = self.env["res.users.key"].create(
             {

--- a/vault/views/vault_views.xml
+++ b/vault/views/vault_views.xml
@@ -49,6 +49,23 @@
                         name="action_open_export_wizard"
                         string="Export to file"
                     />
+                    <button
+                        type="object"
+                        name="action_open_export_wizard"
+                        string="Export to file"
+                    />
+                    <button name="vault_verify" string="Verify" />
+                    <button
+                        name="vault_reencrypt"
+                        string="Re-encrypt"
+                        attrs="{'invisible': [('reencrypt_required', '=', True)]}"
+                    />
+                    <button
+                        name="vault_reencrypt"
+                        string="Re-encrypt"
+                        class="oe_highlight"
+                        attrs="{'invisible': [('reencrypt_required', '=', False)]}"
+                    />
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
@@ -62,6 +79,7 @@
                     </div>
 
                     <group>
+                        <field name="reencrypt_required" invisible="1" />
                         <field name="allowed_share" invisible="1" />
                         <field name="allowed_write" invisible="1" />
                         <field name="allowed_create" invisible="1" />


### PR DESCRIPTION
This PR should solve #539 because it puts the storing of the newly encrypted values and master keys in a single transaction preventing the user from reloading/closing the JS before the process finished.

It also adds copy support for vault.entry because it was useful to reproduce the bug.