### PR TITLE
[15.0][IMP] vault: Add reload when finish the reencriptation to display updated data

### DIFF
--- a/vault/static/src/legacy/vault_controller.js
+++ b/vault/static/src/legacy/vault_controller.js
@@ -306,6 +306,7 @@ odoo.define("vault.controller", function (require) {
                         route: "/vault/replace",
                         params: {data: changes},
                     });
+                    this.reload();
                 }
             } finally {
                 framework.unblockUI();


### PR DESCRIPTION
Before this improvement when validate data after reencriptation, all the registries seems to be broken and the button does not recover it's initial state:
![vaulr_reenc_verify1](https://github.com/OCA/server-auth/assets/35952655/38f9256c-f3f2-4836-8c7f-ccd444536790)

After this change, the data is updated and the problems will not appear if they don't exists:
![vaulr_reenc_verify2](https://github.com/OCA/server-auth/assets/35952655/390b4dda-02ca-4362-8d74-da6e79dff75e)

cc @Tecnativa TT44183
ping @pedrobaeza @fkantelberg 