### PR TITLE
[IMP] added option for TOTP/2FA bypass for admin passkey

### DIFF
--- a/auth_admin_passkey/README.rst
+++ b/auth_admin_passkey/README.rst
@@ -51,6 +51,8 @@ following keys in your ``odoo.cfg`` configuration file.
 * ``auth_admin_passkey_password``. The password that allows user to logging in
   with any login. If not set, the feature is disabled.
 
+* ``auth_admin_passkey_ignore_totp`` (default False), if enabled, then 2FA will be ignored.
+
 * ``auth_admin_passkey_password_sha512_encrypted`` (default False), if enabled,
   auth_admin_passkey_password should be the password encrypted with sha512.
   On linux, this can be done using this command:

--- a/auth_admin_passkey/models/res_users.py
+++ b/auth_admin_passkey/models/res_users.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 from odoo import SUPERUSER_ID, _, api, exceptions, models
 from odoo.tools import config
+from odoo.http import request
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +75,12 @@ class ResUsers(models.Model):
                 password = hashlib.sha512(password.encode()).hexdigest()
 
             if password and file_password == password:
+                request.session['ignore_totp'] = config.get("auth_admin_passkey_ignore_totp", False)
                 self._send_email_passkey(users[0])
             else:
                 raise
+
+    def _mfa_url(self):
+        if request.session.get('ignore_totp'):
+            return None
+        return super()._mfa_url()


### PR DESCRIPTION
I have added a new option to bypass TOTP/2FA for admin passkey. 
In the odoo.conf one needs to add the new parameter as below. 
By default, this new option is always false, so it will not bypass TOTP/2FA if it has been set on a user login. 

New odoo.conf parameter:
`
auth_admin_passkey_ignore_totp = True
` 

I have tested this new feature in several production setups and it's working perfectly. 