### PR TITLE
[FIX] auth_saml: decrypt matching_value response to compare output response.name_id.text

### DIFF
--- a/auth_saml/models/auth_saml_provider.py
+++ b/auth_saml/models/auth_saml_provider.py
@@ -232,6 +232,9 @@ class AuthSamlProvider(models.Model):
             "cert_file": self._get_cert_key_path("sp_pem_public"),
             "key_file": self._get_cert_key_path("sp_pem_private"),
         }
+        settings["encryption_keypairs"] = [
+            {"key_file": settings["key_file"], "cert_file": settings["cert_file"]}
+        ]
         sp_config = Saml2Config()
         sp_config.load(settings)
         sp_config.allow_unknown_attributes = True


### PR DESCRIPTION
Decrypt matching_value response to compare output response with response.name_id.text. It shows AttributeError: 'NoneType' object has no attribute 'text'.

```python
2023-09-17 02:02:54,015 4049 ERROR odoo odoo.addons.auth_saml.controllers.main: SAML2: failure - 'NoneType' object has no attribute 'text'
Traceback (most recent call last):
  File "/home/odoo/instance/extra_addons/server-auth/auth_saml/controllers/main.py", line 219, in signin
    .auth_saml(
  File "/home/odoo/instance/extra_addons/server-auth/auth_saml/models/res_users.py", line 64, in auth_saml
    validation = self._auth_saml_validate(provider, saml_response, base_url)
  File "/home/odoo/instance/extra_addons/server-auth/auth_saml/models/res_users.py", line 29, in _auth_saml_validate
    return provider._validate_auth_response(token, base_url)
  File "/home/odoo/instance/extra_addons/server-auth/auth_saml/models/auth_saml_provider.py", line 296, in _validate_auth_response
    matching_value = response.name_id.text
AttributeError: 'NoneType' object has no attribute 'text'
```

Check [class SecurityContext in saml2 lib](https://github.com/IdentityPython/pysaml2/blob/master/src/saml2/sigver.py#L1186)

Fixes #553 