### PR TITLE
[16.0][IMP] auth_session_timeout adapt to use websocket instead of longpolling

### DIFF
--- a/auth_session_timeout/data/ir_config_parameter_data.xml
+++ b/auth_session_timeout/data/ir_config_parameter_data.xml
@@ -9,6 +9,6 @@
     </record>
     <record id="inactive_session_time_out_ignored_url" model="ir.config_parameter">
         <field name="key">inactive_session_time_out_ignored_url</field>
-        <field name="value">/calendar/notify,/longpolling/poll</field>
+        <field name="value">/calendar/notify,/bus/im_status</field>
     </record>
 </odoo>


### PR DESCRIPTION
Migration leftover see: 
https://github.com/OCA/server-auth/pull/507#pullrequestreview-1603549270
