### PR TITLE
[12.0] Add lasso test requirement

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 # auth_oidc tests
 responses
+lasso @ https://dev.entrouvert.org/releases/lasso/lasso-2.8.1.tar.gz


### PR DESCRIPTION
This lib, which is a dependency of auth_saml, is not on PyPI