### PR TITLE
[12.0] Remove lasso external dependency from PyPI package.

### DIFF
--- a/setup/auth_saml/setup.py
+++ b/setup/auth_saml/setup.py
@@ -1,6 +1,12 @@
 import setuptools
 
 setuptools.setup(
-    setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
+    setup_requires=["setuptools-odoo"],
+    odoo_addon={
+        "external_dependencies_override": {
+            "python": {
+                "lasso": [],
+            }
+        }
+    },
 )


### PR DESCRIPTION
This lib is not on PyPI and it does not seem to be easily installable in runboat/oca-ci.