### PR TITLE
[16.0][FIX] *_ropc: walrus operator not on python 3.7

### DIFF
--- a/auth_oauth_ropc/models/res_users.py
+++ b/auth_oauth_ropc/models/res_users.py
@@ -17,7 +17,9 @@ class ResUsers(models.Model):
                 env["interactive"] or not self.env.user._rpc_api_keys_only()
             )
             if passwd_allowed and self.env.user.active:
-                if ropc_provider := self.env["oauth.ropc.provider"].sudo().search([]):
-                    if ropc_provider._authenticate(self.env.user.login, password):
-                        return
+                ropc_provider = self.env["oauth.ropc.provider"].sudo().search([])
+                if ropc_provider and ropc_provider._authenticate(
+                    self.env.user.login, password
+                ):
+                    return
             raise


### PR DESCRIPTION
Remove an assignment expression (walrus operator) from the code, as these are introduced with python 3.8, whereas the minimum python version for Odoo 16.0 is python 3.7.