### PR TITLE
[15.0][FIX] password_security: Allow password hash updates

### DIFF
--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -215,7 +215,7 @@ class ResUsers(models.Model):
         res = super(ResUsers, self)._set_encrypted_password(uid, pw)
         if not self.env.user.company_id.password_policy_enabled:
             return res
-        self.write({"password_history_ids": [(0, 0, {"password_crypt": pw})]})
+        self.sudo().write({"password_history_ids": [(0, 0, {"password_crypt": pw})]})
         return res
 
     def action_reset_password(self):


### PR DESCRIPTION
Updating the password hash fails, if "_set_encrypted_password" is called as a regular user.

The core _set_encrypted_password method executes a direct query without any access checks, so we assume it's safe to operate with sudo() here.

The problem was seen after https://github.com/odoo/odoo/pull/146865 where hash strength is increased, resulting in password hash updates without a normal password change.