### PR TITLE
[16.0][FIX] users_ldap_groups: safe LDAP decode

### DIFF
--- a/users_ldap_groups/models/res_company_ldap_operator.py
+++ b/users_ldap_groups/models/res_company_ldap_operator.py
@@ -1,6 +1,7 @@
 # Copyright 2012-2018 Therp BV <https://therp.nl>
 # Copyright 2018 Brainbean Apps <https://brainbeanapps.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+import base64
 from logging import getLogger
 from string import Template
 
@@ -32,10 +33,27 @@ class ResCompanyLdapOperator(models.AbstractModel):
 
     def _query(self, ldap_entry, mapping):
         query_string = Template(mapping.value).safe_substitute(
-            {attr: ldap_entry[1][attr][0].decode() for attr in ldap_entry[1]}
+            {
+                attr: self.safe_ldap_decode(ldap_entry[1][attr][0])
+                for attr in ldap_entry[1]
+            }
         )
 
         results = mapping.ldap_id._query(mapping.ldap_id.read()[0], query_string)
         _logger.debug('Performed LDAP query "%s" results: %s', query_string, results)
 
         return bool(results)
+
+    def safe_ldap_decode(self, attr):
+        """Safe LDAP decode; Base64 encode attributes containing binary data.
+        Binary data can be stored in Active Directory, e.g., thumbnailPhoto is
+        stored as binary. As Str.decoce() cannot handle binary, this method
+        Base64 encodes the data in the attribute, instead, if decode fails.
+        Using Base64 should be a suitable fallback, because the use cases of
+        users_ldap_groups do not really require comparing binary attributes.
+        """
+
+        try:
+            return attr.decode()
+        except UnicodeDecodeError:
+            return base64.b64encode(attr)


### PR DESCRIPTION
The group mapping in query mode fails if LDAP returns binary data in any of the fields. This adds a function that handles such situation by base64 encoding it.