### PR TITLE
[14.0][FIX] auth_saml: password reset when deactivating the config settings

### DIFF
--- a/auth_saml/models/ir_config_parameter.py
+++ b/auth_saml/models/ir_config_parameter.py
@@ -27,3 +27,13 @@ class IrConfigParameter(models.Model):
         if self.filtered(lambda param: param.key == ALLOW_SAML_UID_AND_PASSWORD):
             self.env["res.users"].allow_saml_and_password_changed()
         return result
+
+    def unlink(self):
+        """Redefined to update users when our parameter is deleted."""
+        param_saml = self.filtered(
+            lambda param: param.key == ALLOW_SAML_UID_AND_PASSWORD
+        )
+        result = super().unlink()
+        if result and param_saml:
+            self.env["res.users"].allow_saml_and_password_changed()
+        return result

--- a/auth_saml/tests/test_pysaml.py
+++ b/auth_saml/tests/test_pysaml.py
@@ -179,7 +179,7 @@ class TestPySaml(HttpCase):
         # User should now be able to log in with the token
         self.authenticate(user="test@example.com", password=token)
 
-    def test_disallow_user_password_when_changing_setting(self):
+    def test_disallow_user_password_when_changing_ir_config_parameter(self):
         """Test that disabling users from having both a password and SAML ids remove
         users password."""
         # change the option
@@ -273,3 +273,26 @@ class TestPySaml(HttpCase):
         ).value = "False"
         # Test base.user_admin exception
         self.env.ref("base.user_admin").password = "nNRST4j*->sEatNGg._!"
+
+    def test_disallow_user_password_when_changing_settings(self):
+        """Test that disabling the setting will remove passwords from related users"""
+        # We activate the settings to allow password login
+        self.env["res.config.settings"].create(
+            {
+                "allow_saml_uid_and_internal_password": True,
+            }
+        ).execute()
+
+        # Test the user can login with the password
+        self.authenticate(user="user@example.com", password="NesTNSte9340D720te>/-A")
+
+        self.env["res.config.settings"].create(
+            {
+                "allow_saml_uid_and_internal_password": False,
+            }
+        ).execute()
+
+        with self.assertRaises(AccessDenied):
+            self.authenticate(
+                user="user@example.com", password="NesTNSte9340D720te>/-A"
+            )


### PR DESCRIPTION
**issue**
- have users with password
- install the module `auth_saml`
- activate the paramter that allows to login with the password
- setup of the user with the saml provider
- update the settings by removing the possibility to log with the password

This will delete the ir.config parameter, but not trigger the removal of the password.

**Fix**
Now when we update the settings and unlink the related ir.config.parameter. We trigger the removal of passwords

Once this PR is merged, I'll forward port it to next versions