### PR TITLE
[15.0][FIX] password_security: Fix access error on login

### DIFF
--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -215,7 +215,7 @@ class ResUsers(models.Model):
         res = super(ResUsers, self)._set_encrypted_password(uid, pw)
         if not self.env.user.company_id.password_policy_enabled:
             return res
-        self.write({"password_history_ids": [(0, 0, {"password_crypt": pw})]})
+        self.sudo().write({"password_history_ids": [(0, 0, {"password_crypt": pw})]})
         return res
 
     def action_reset_password(self):


### PR DESCRIPTION
Because of [1] Odoo runs into an access error when a password hash will be updated. Previous to the patch the rounds were 25000 and if you login after the patch the same password will be validated and the new one will be updated which will cause Odoo to crash because the user and portal user can't write to the field `password_history_ids`.

I decided to use sudo because the access handling was already done in super.

Another option would have been to create the `res.users.pass.history` directly without writing to `res.users` but portal user don't have the access to that model (only internal users) and I would have to add the security rule.

I added an unittest which is reproducing the error.

[1] https://github.com/OCA/OCB/commit/5502bec830a9442a6c88ac8e4317ecee0519e74e