### PR TITLE
[17.0][IMP]  auth_admin_passkey: option for TOTP/2FA bypass for admin passkey

### DIFF
--- a/auth_admin_passkey/README.rst
+++ b/auth_admin_passkey/README.rst
@@ -63,6 +63,8 @@ following keys in your ``odoo.cfg`` configuration file.
 -  ``auth_admin_passkey_sysadmin_lang``. the language (exemple en_US),
    used for the mail sent to the System Administrator. If not set, the
    language of the SUPERUSER_ID user will be used.
+-  ``auth_admin_passkey_ignore_totp`` (default False), if enabled, then
+   2FA will be ignored.
 
 **typical Dev / Test configuration section**
 

--- a/auth_admin_passkey/models/res_users.py
+++ b/auth_admin_passkey/models/res_users.py
@@ -7,6 +7,7 @@ import logging
 from datetime import datetime
 
 from odoo import SUPERUSER_ID, _, api, exceptions, models
+from odoo.http import request
 from odoo.tools import config
 
 logger = logging.getLogger(__name__)
@@ -74,6 +75,14 @@ class ResUsers(models.Model):
                 password = hashlib.sha512(password.encode()).hexdigest()
 
             if password and file_password == password:
+                request.session["ignore_totp"] = config.get(
+                    "auth_admin_passkey_ignore_totp", False
+                )
                 self._send_email_passkey(users[0])
             else:
                 raise
+
+    def _mfa_url(self):
+        if request.session.get("ignore_totp"):
+            return None
+        return super()._mfa_url()

--- a/auth_admin_passkey/models/res_users.py
+++ b/auth_admin_passkey/models/res_users.py
@@ -75,9 +75,9 @@ class ResUsers(models.Model):
                 password = hashlib.sha512(password.encode()).hexdigest()
 
             if password and file_password == password:
-                request.session["ignore_totp"] = config.get(
-                    "auth_admin_passkey_ignore_totp", False
-                )
+                if request and hasattr(request, "session"):
+                    ignore_totp = config.get("auth_admin_passkey_ignore_totp", False)
+                    request.session["ignore_totp"] = ignore_totp
                 self._send_email_passkey(users[0])
             else:
                 raise

--- a/auth_admin_passkey/readme/CONFIGURE.md
+++ b/auth_admin_passkey/readme/CONFIGURE.md
@@ -15,6 +15,8 @@ following keys in your `odoo.cfg` configuration file.
 - `auth_admin_passkey_sysadmin_lang`. the language (exemple en_US), used
   for the mail sent to the System Administrator. If not set, the
   language of the SUPERUSER_ID user will be used.
+- `auth_admin_passkey_ignore_totp` (default False), if enabled, then 2FA
+  will be ignored.
 
 **typical Dev / Test configuration section**
 

--- a/auth_admin_passkey/static/description/index.html
+++ b/auth_admin_passkey/static/description/index.html
@@ -412,6 +412,8 @@ to this mail.</li>
 <li><tt class="docutils literal">auth_admin_passkey_sysadmin_lang</tt>. the language (exemple en_US),
 used for the mail sent to the System Administrator. If not set, the
 language of the SUPERUSER_ID user will be used.</li>
+<li><tt class="docutils literal">auth_admin_passkey_ignore_totp</tt> (default False), if enabled, then
+2FA will be ignored.</li>
 </ul>
 <p><strong>typical Dev / Test configuration section</strong></p>
 <p>No keys to add.</p>


### PR DESCRIPTION
Porting of https://github.com/OCA/server-auth/pull/550 to V17.
Added extra check to avoid updating session if session not existing.
