### PR TITLE
[14.0] [FIX] auth_jwt: Unhandled PyJWKClientError in _get_key

### DIFF
--- a/auth_jwt/models/auth_jwt_validator.py
+++ b/auth_jwt/models/auth_jwt_validator.py
@@ -189,10 +189,10 @@ class AuthJwtValidator(models.Model):
         else:
             try:
                 header = jwt.get_unverified_header(token)
+                key = self._get_key(header.get("kid"))  # Can raise PyJWKClientError
             except Exception as e:
                 _logger.info("Invalid token: %s", e)
                 raise UnauthorizedInvalidToken() from e
-            key = self._get_key(header.get("kid"))
             algorithm = self.public_key_algorithm
         try:
             payload = jwt.decode(


### PR DESCRIPTION
This commit https://github.com/OCA/server-auth/commit/5e726ac0084de377a046308d21bf39fa05ad3f4c breaks the next_validator_id loop.

`_get_key` calls `jwks_client.get_signing_key(kid)` which can raise PyJWKClientError which is not caught by the validation loop (only catching Unauthorized)

Putting `_get_key` in the preceding try except fix this problem since it catches all Exception
