### PR TITLE
[14.0] [FIX] auth_api_key: return 401 instead of 403

### DIFF
--- a/auth_api_key/models/ir_http.py
+++ b/auth_api_key/models/ir_http.py
@@ -5,8 +5,9 @@
 
 import logging
 
+from werkzeug.exceptions import Unauthorized
+
 from odoo import models
-from odoo.exceptions import AccessDenied
 from odoo.http import request
 
 _logger = logging.getLogger(__name__)
@@ -33,4 +34,4 @@ class IrHttp(models.AbstractModel):
                 request.auth_api_key_id = auth_api_key.id
                 return True
         _logger.error("Wrong HTTP_API_KEY, access denied")
-        raise AccessDenied()
+        raise Unauthorized()


### PR DESCRIPTION
`AccessDenied()` has status code `403` while, [according to the docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403) the status code `401` [suits better in this case](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) so I would like to propose to use `werkzeug.exceptions.Unauthorized` instead, which returns `401`.