### PR TITLE
[16.0][FIX] Prevent lxml import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # generated from manifests external_dependencies
 cryptography
 email_validator
-lxml
+lxml==4.6.5 ; python_version <= '3.10'  # min version = 4.5.0 (Focal - with security backports)
+lxml==4.9.2 ; python_version > '3.10'
 pyjwt
 pysaml2
 python-jose


### PR DESCRIPTION
**Description**
- As of today, using the _**latest**_ version of the _lxml_ Python dependency (currently `5.2.1`) will throw the below error when starting up Odoo:
  
  >Traceback (most recent call last):
    File "/usr/bin/odoo", line 3, in <module>
      import odoo
    File "/usr/lib/python3/dist-packages/odoo/__init__.py", line 125, in <module>
      from . import modules
    File "/usr/lib/python3/dist-packages/odoo/modules/__init__.py", line 8, in <module>
      from . import db, graph, loading, migration, module, registry, neutralize
    File "/usr/lib/python3/dist-packages/odoo/modules/graph.py", line 11, in <module>
      import odoo.tools as tools
    File "/usr/lib/python3/dist-packages/odoo/tools/__init__.py", line 16, in <module>
      from .mail import *
    File "/usr/lib/python3/dist-packages/odoo/tools/mail.py", line 19, in <module>
      from lxml.html import clean
    File "/home/odoo/.local/lib/python3.10/site-packages/lxml/html/clean.py", line 18, in <module>
      raise ImportError(
  ImportError: lxml.html.clean module is now a separate project lxml_html_clean.
  Install lxml[html_clean] or lxml_html_clean directly.

**Fix**
- Use instead the _lxml_ version found within the official Odoo requirements:
   - https://github.com/odoo/odoo/blob/c21be6c9cdc8500d96ae15c5f529598167a45365/requirements.txt#L23

**Impacted versions**
- All Odoo versions that use the _latest_ for this dependency.

**References**
- https://github.com/napari/napari/issues/6798