### PR TITLE
[14.0] Add module base_user_empty_password

### DIFF
--- a/base_user_empty_password/__init__.py
+++ b/base_user_empty_password/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/base_user_empty_password/__manifest__.py
+++ b/base_user_empty_password/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Empty users password",
+    "summary": "Allows to empty password of users",
+    "version": "14.0.1.0.0",
+    "development_status": "Beta",
+    "category": "Uncategorized",
+    "website": "https://github.com/OCA/server-auth",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["grindtildeath"],
+    "license": "AGPL-3",
+    "depends": [
+        "base",
+    ],
+    "data": [
+        # "data/ir_actions.xml",
+        "security/ir.model.access.csv",
+        "views/res_users.xml",
+        "wizard/empty_password.xml",
+    ],
+}

--- a/base_user_empty_password/models/__init__.py
+++ b/base_user_empty_password/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_users

--- a/base_user_empty_password/models/res_users.py
+++ b/base_user_empty_password/models/res_users.py
@@ -1,0 +1,25 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    has_password = fields.Boolean(compute="_compute_has_password")
+
+    def _compute_has_password(self):
+        # Bypass ORM as password is always empty in cache
+        self.env.cr.execute(
+            """SELECT id, password FROM res_users WHERE id IN %s;""", (tuple(self.ids),)
+        )
+        res = {row[0]: row[1] for row in self.env.cr.fetchall()}
+        for user in self:
+            user.has_password = bool(res.get(user.id))
+
+    def _empty_password(self):
+        # Update in DB to avoid using crypt context
+        self.env.cr.execute(
+            """UPDATE res_users SET password = %s WHERE id IN %s""",
+            ("", (tuple(self.ids),)),
+        )

--- a/base_user_empty_password/readme/CONTRIBUTORS.md
+++ b/base_user_empty_password/readme/CONTRIBUTORS.md
@@ -1,0 +1,1 @@
+- Akim Juillerat <akim.juilllerat@camptocamp.com>

--- a/base_user_empty_password/readme/DESCRIPTION.md
+++ b/base_user_empty_password/readme/DESCRIPTION.md
@@ -1,0 +1,3 @@
+This module provides a wizard to allow emptying users password field.
+
+This could be useful to force the user to use another sign on method than Odoo.

--- a/base_user_empty_password/security/ir.model.access.csv
+++ b/base_user_empty_password/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_empty_password_wizard,access_empty_password_wizard,model_empty_password_wizard,base.group_erp_manager,1,1,1,1

--- a/base_user_empty_password/views/res_users.xml
+++ b/base_user_empty_password/views/res_users.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_users_form" model="ir.ui.view">
+        <field name="name">res.users.form</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//notebook" position="before">
+                <group name="password_defined" groups="base.group_no_one">
+                    <field name="has_password" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/base_user_empty_password/wizard/__init__.py
+++ b/base_user_empty_password/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import empty_password

--- a/base_user_empty_password/wizard/empty_password.py
+++ b/base_user_empty_password/wizard/empty_password.py
@@ -1,0 +1,24 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class EmptyPasswordWizard(models.TransientModel):
+    _name = "empty.password.wizard"
+    _description = "Empty Password Wizard"
+
+    user_ids = fields.Many2many(
+        "res.users", readonly=True, default=lambda w: w._default_user_ids()
+    )
+
+    def _default_user_ids(self):
+        return (
+            self.env.context.get("active_model") == "res.users"
+            and self.env.context.get("active_ids")
+            or []
+        )
+
+    def empty_password_button(self):
+        self.ensure_one()
+        self.user_ids._empty_password()
+        return {"type": "ir.actions.client", "tag": "reload"}

--- a/base_user_empty_password/wizard/empty_password.xml
+++ b/base_user_empty_password/wizard/empty_password.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="empty_password_wizard_view" model="ir.ui.view">
+        <field name="name">Empty Password</field>
+        <field name="model">empty.password.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Empty Password">
+                <field name="user_ids" invisible="1" />
+                <div>
+                    <p>Are you sure you want to empty password of selected users?</p>
+                </div>
+                <footer>
+                    <button
+                        string="Empty Password"
+                        name="empty_password_button"
+                        type="object"
+                        class="btn-primary"
+                    />
+                    <button string="Cancel" class="btn-secondary" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+    <record id="empty_password_wizard_action" model="ir.actions.act_window">
+        <field name="name">Empty Password</field>
+        <field name="res_model">empty.password.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="binding_model_id" ref="base.model_res_users" />
+    </record>
+</odoo>

--- a/setup/base_user_empty_password/odoo/addons/base_user_empty_password
+++ b/setup/base_user_empty_password/odoo/addons/base_user_empty_password
@@ -1,0 +1,1 @@
+../../../../base_user_empty_password

--- a/setup/base_user_empty_password/setup.py
+++ b/setup/base_user_empty_password/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module provides a wizard to allow emptying users password field.

This could be useful to force the user to use another sign on method than Odoo.
