### PR TITLE
[15.0][FIX] auth_saml: do not force using vulnerable cryptography module

### DIFF
--- a/auth_saml/__manifest__.py
+++ b/auth_saml/__manifest__.py
@@ -12,14 +12,7 @@
     "license": "AGPL-3",
     "depends": ["base_setup", "web"],
     "external_dependencies": {
-        # Place an upper bound on cryptography version to be compatible with
-        # pyopenssl 19 mentioned in Odoo 15's requirements.txt. If we don't do
-        # this, installing this module will try to upgrade cryptography to the latest
-        # version because the minimum required version in pysaml2 (>=3.1) is greater than
-        # version 2.6 (from Odoo's requirement.txt). Since cryptography/pyopenssl don't
-        # declare minimum supported versions, this lead to inconsistencies.
-        # https://github.com/OCA/server-auth/issues/424
-        "python": ["pysaml2", "cryptography<37"],
+        "python": ["pysaml2"],
         "bin": ["xmlsec1"],
         # special definition used by OCA to install packages
         "deb": ["xmlsec1"],

--- a/auth_saml/readme/INSTALL.rst
+++ b/auth_saml/readme/INSTALL.rst
@@ -1,3 +1,8 @@
 This addon requires the python module ``pysaml2``.
 
 ``pysaml2`` requires the binary ``xmlsec1`` (on Debian or Ubuntu you can install it with ``apt-get install xmlsec1``)
+
+When following the requirements.txt from odoo, the cryptography module must not be the latest version, otherwise it is incompatible with pyopenssl 19.
+This is necessary because old cryptography/pyopenssl don't declare minimum supported versions.
+It is possible to use newer version of those libraries, eventually patching the Odoo core to stay compatible.
+As this issue is not related to this module, nothing is enforced at the module level.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # generated from manifests external_dependencies
-cryptography<37
 email_validator
 lxml
 pysaml2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,3 @@
 responses
+# necessary to avoid incompatibilities with pyopenssl
+cryptography<37


### PR DESCRIPTION
Without this fix, it is impossible to use an upgraded version of cryptography with this module.

It is still necessary to check for compatibility, so that information is added to the install instructions.