### PR TITLE
[15.0][FIX] password_security: fix Policy applied to reset password dialog

### DIFF
--- a/password_security/README.rst
+++ b/password_security/README.rst
@@ -122,6 +122,9 @@ Contributors
 * `Onestein <https://www.onestein.nl>`_:
     * Andrea Stirpe <a.stirpe@onestein.nl>
 
+* `WT-IO-IT GmbH <https://www.wt-io-it.at>`_:
+    * Andreas Perhab <andreas.perhab@wt-io-it.at>
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/password_security/__manifest__.py
+++ b/password_security/__manifest__.py
@@ -25,6 +25,7 @@
     "license": "LGPL-3",
     "data": [
         "views/res_config_settings_views.xml",
+        "views/signup_templates.xml",
         "security/ir.model.access.csv",
         "security/res_users_pass_history.xml",
     ],
@@ -32,6 +33,9 @@
         "web.assets_common": [
             "/password_security/static/src/js/password_gauge.js",
             "/password_security/static/lib/zxcvbn/zxcvbn.min.js",
+        ],
+        "web.assets_frontend": [
+            "/password_security/static/src/js/signup_policy.js",
         ],
         "web.qunit_suite_tests": [
             "password_security/static/tests/**/*",

--- a/password_security/controllers/main.py
+++ b/password_security/controllers/main.py
@@ -50,6 +50,19 @@ class PasswordSecurityHome(AuthSignupHome):
         redirect = request.env.user.partner_id.signup_url
         return request.redirect(redirect)
 
+    def get_auth_signup_config(self):
+        signup_config = super().get_auth_signup_config()
+        for property_name in (
+            "password_length",
+            "password_lower",
+            "password_upper",
+            "password_numeric",
+            "password_special",
+            "password_estimate",
+        ):
+            signup_config[property_name] = request.env.company[property_name]
+        return signup_config
+
     @http.route()
     def web_auth_signup(self, *args, **kw):
         try:

--- a/password_security/readme/CONTRIBUTORS.rst
+++ b/password_security/readme/CONTRIBUTORS.rst
@@ -13,3 +13,6 @@
 
 * `Onestein <https://www.onestein.nl>`_:
     * Andrea Stirpe <a.stirpe@onestein.nl>
+
+* `WT-IO-IT GmbH <https://www.wt-io-it.at>`_:
+    * Andreas Perhab <andreas.perhab@wt-io-it.at>

--- a/password_security/static/description/index.html
+++ b/password_security/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -512,6 +511,14 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <dt><a class="reference external" href="https://www.onestein.nl">Onestein</a>:</dt>
 <dd><ul class="first last simple">
 <li>Andrea Stirpe &lt;<a class="reference external" href="mailto:a.stirpe&#64;onestein.nl">a.stirpe&#64;onestein.nl</a>&gt;</li>
+</ul>
+</dd>
+</dl>
+</li>
+<li><dl class="first docutils">
+<dt><a class="reference external" href="https://www.wt-io-it.at">WT-IO-IT GmbH</a>:</dt>
+<dd><ul class="first last simple">
+<li>Andreas Perhab &lt;<a class="reference external" href="mailto:andreas.perhab&#64;wt-io-it.at">andreas.perhab&#64;wt-io-it.at</a>&gt;</li>
 </ul>
 </dd>
 </dl>

--- a/password_security/static/src/js/signup_policy.js
+++ b/password_security/static/src/js/signup_policy.js
@@ -3,39 +3,40 @@
 odoo.define("password_security.signup.policy", function (require) {
     "use strict";
 
-    var base = require("web_editor.base");
     var policy = require("auth_password_policy");
     var PasswordMeter = require("auth_password_policy.Meter");
+    // Wait until auth_password_policy_signup.policy is done
+    require("auth_password_policy_signup.policy");
 
-    base.ready().then(function () {
-        var $signupForm = $(".oe_signup_form, .oe_reset_password_form");
-        if (!$signupForm.length) {
-            return;
-        }
+    var $signupForm = $(".oe_signup_form, .oe_reset_password_form");
+    if (!$signupForm.length) {
+        return;
+    }
 
-        var $password = $signupForm.find("#password");
-        var password_length = Number($password.attr("password_length"));
-        var password_lower = Number($password.attr("password_lower"));
-        var password_upper = Number($password.attr("password_upper"));
-        var password_numeric = Number($password.attr("password_numeric"));
-        var password_special = Number($password.attr("password_special"));
-        var password_estimate = Number($password.attr("password_estimate"));
+    var $password = $signupForm.find("#password");
+    var password_length = Number($password.attr("passwordlength"));
+    var password_lower = Number($password.attr("passwordlower"));
+    var password_upper = Number($password.attr("passwordupper"));
+    var password_numeric = Number($password.attr("passwordnumeric"));
+    var password_special = Number($password.attr("passwordspecial"));
+    var password_estimate = Number($password.attr("passwordestimate"));
 
-        var meter = new PasswordMeter(
-            null,
-            new policy.Policy({
-                password_length: password_length,
-                password_lower: password_lower,
-                password_upper: password_upper,
-                password_numeric: password_numeric,
-                password_special: password_special,
-                password_estimate: password_estimate,
-            }),
-            policy.recommendations
-        );
-        meter.insertAfter($password);
-        $password.on("input", function () {
-            meter.update($password.val());
-        });
+    var meter = new PasswordMeter(
+        null,
+        new policy.Policy({
+            password_length: password_length,
+            password_lower: password_lower,
+            password_upper: password_upper,
+            password_numeric: password_numeric,
+            password_special: password_special,
+            password_estimate: password_estimate,
+        }),
+        policy.recommendations
+    );
+    // Remove the old meter
+    $password.parent().find("meter").remove();
+    meter.insertAfter($password);
+    $password.on("input", function () {
+        meter.update($password.val());
     });
 });

--- a/password_security/views/signup_templates.xml
+++ b/password_security/views/signup_templates.xml
@@ -1,0 +1,16 @@
+<odoo>
+    <template
+        id="fields"
+        inherit_id="auth_signup.fields"
+        name="Password Security data for auth_signup"
+    >
+        <xpath expr="//input[@name='password']" position="attributes">
+            <attribute name="t-att-passwordlength">password_length</attribute>
+            <attribute name="t-att-passwordlower">password_lower</attribute>
+            <attribute name="t-att-passwordupper">password_upper</attribute>
+            <attribute name="t-att-passwordnumeric">password_numeric</attribute>
+            <attribute name="t-att-passwordspecial">password_special</attribute>
+            <attribute name="t-att-passwordestimate">password_estimate</attribute>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Add password_security settings as attributes to password input field for signup_policy.js to be able to pick them up. Also enable signup_policy.js to be loaded on /web/reset_password.

Previously the settings from password_security were not taken into consideration for the password reset form and the error message when hovering over the password strength meter always stated `Required: at least 4 characters` even when the settings where set to 12 characters or something different:
[Screencast from 2024-05-06 16:07:25.webm](https://github.com/OCA/server-auth/assets/38032588/1c11d35c-6b43-4462-a8b2-6d2c67836b94)
![Screenshot from 2024-05-06 17-29-43](https://github.com/OCA/server-auth/assets/38032588/a4480125-f055-41d9-b010-c977925f80c2)



Issue tested on runboat with: http://oca-server-auth-15-0-884f003b6318.runboat.odoo-community.org/web/reset_password?db=ba124a0ef-fd32-452f-b362-a2b0ab3b2a88&token=VZEHfqvUItBVyfAGimQu

With this change the settings from password_security are correctly applied to /web/reset_password password strenght meter.

New message is correct:
![Screenshot from 2024-05-06 17-25-33](https://github.com/OCA/server-auth/assets/38032588/79b3bfec-4623-4be6-adad-e9185a8e9a61)


Info @wt-io-it