### PR TITLE
Fix: replace tenant id for single tentant

### DIFF
--- a/auth_oidc/README.rst
+++ b/auth_oidc/README.rst
@@ -79,6 +79,7 @@ companies can use their AzureAD login without an guest account.
 -  Client ID: Application (client) id
 -  Client Secret: Client secret
 -  Allowed: yes
+-  replace {tenant_id} in urls with your Azure tenant id
 
 or
 
@@ -86,7 +87,6 @@ or
 -  Client ID: Application (client) id
 -  Client Secret: Client secret
 -  Allowed: yes
--  replace {tenant_id} in urls with your Azure tenant id
 
 |image2|
 


### PR DESCRIPTION
Moved `-  replace {tenant_id} in urls with your Azure tenant id` to the correct section in the readme.