### PR TITLE
[FIX] password_security: Access company as superuser

### DIFF
--- a/password_security/controllers/main.py
+++ b/password_security/controllers/main.py
@@ -60,7 +60,7 @@ class PasswordSecurityHome(AuthSignupHome):
             "password_special",
             "password_estimate",
         ):
-            signup_config[property_name] = request.env.company[property_name]
+            signup_config[property_name] = request.env(su=True).company[property_name]
         return signup_config
 
     @http.route()


### PR DESCRIPTION
Seems like user may not always have access to company - access with su=True should be safe for reading these properties