### PR TITLE
[16.0][IMP][auth_saml] Res.users autoprovisioning feature on login

### DIFF
--- a/auth_saml/models/__init__.py
+++ b/auth_saml/models/__init__.py
@@ -4,6 +4,7 @@ from . import (
     auth_saml_attribute_mapping,
     auth_saml_provider,
     auth_saml_request,
+    auth_saml_domain,
     ir_config_parameter,
     res_config_settings,
     res_users,

--- a/auth_saml/models/auth_saml_domain.py
+++ b/auth_saml/models/auth_saml_domain.py
@@ -1,0 +1,10 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+class AuthSamlDomain(models.Model):
+    """List of domains for SAML auto-provisioning"""
+    _name = "auth.saml.domain"
+    _description = "SAML2 domains in autoprovisioning"
+
+    name = fields.Char("Domain Name", required=True)

--- a/auth_saml/models/auth_saml_provider.py
+++ b/auth_saml/models/auth_saml_provider.py
@@ -98,6 +98,16 @@ class AuthSamlProvider(models.Model):
         help="Only the provider with the higher priority will be automatically "
         "redirected",
     )
+    saml_domain_ids = fields.Many2many(
+        "auth.saml.domain", string="Domains for auto-provisioning (optional)", required=False,
+        help=("When filled, authorizes automatic user account creation (auto-provisioning) based on this domains whitelist."
+            " Requires the 'matching_attribute' field to have a syntax like prefix@domain, where 'domain' value will"
+            " be search in the whitelist. Recommended: set claims to define 'res_users.name' attribute, or it by default be"
+            " set to saml_uid value for auto-provisioned users. If no domains are given, this feature is disabled and user"
+            " account must be pre-provisioned through Odoo 'Users' interface or with provisioning tools like SCIM."
+            " In this case, non-existing account will raise a error at login like 'Permission denied' or 'No access"
+            " granted to this database'.")
+    )
     sig_alg = fields.Selection(
         selection=lambda s: s._sig_alg_selection(),
         required=True,

--- a/auth_saml/views/auth_saml.xml
+++ b/auth_saml/views/auth_saml.xml
@@ -102,6 +102,10 @@
                             <div>
                                 <field name="autoredirect" />
                             </div>
+                            <label for="saml_domain_ids" />
+                            <div>
+                                <field name="saml_domain_ids" widget="many2many_tags" />
+                            </div>
                             <label for="sp_baseurl" />
                             <div>
                                 <field name="sp_baseurl" widget="url" />


### PR DESCRIPTION
This commit add the possibility for Odoo administrator to specify a list of trusted "domains*" per SAML providers.
When a user tries to authenticate to Odoo using SAML, coming from such domain* & providers, its Odoo res.users account is automatically created (copied from base.default_user) instead of showing him/her 'Permission denied' or 'No access granted to this database'.
*domain refers to the suffix or login used for SAML authentication, like : henry.bernard@domain.com, like from Google, Microsoft, ...

Thus, it removes for Odoo administrators who choose SAML authentication the tasks to pre-create all users manually or through SCIM connectors.
However, it does not remove the need to tailor users access rights after the 1st login of the user.