### PR TITLE
[16.0][FIX] users_ldap_groups JSON RPC vulnerability

### DIFF
--- a/users_ldap_groups/models/res_company_ldap.py
+++ b/users_ldap_groups/models/res_company_ldap.py
@@ -48,7 +48,7 @@ class ResCompanyLdap(models.Model):
             _logger.debug("deleting all groups from user %d", user_id)
             groups.append((5, False, False))
         for mapping in this.group_mapping_ids:
-            operator = getattr(op_obj, mapping.operator)
+            operator = getattr(op_obj, f"_{mapping.operator}")
             _logger.debug("checking mapping %s", mapping)
             if operator(ldap_entry, mapping):
                 _logger.debug(

--- a/users_ldap_groups/models/res_company_ldap_operator.py
+++ b/users_ldap_groups/models/res_company_ldap_operator.py
@@ -20,17 +20,17 @@ class ResCompanyLdapOperator(models.AbstractModel):
         """Return names of function to call on this model as operator"""
         return ("contains", "equals", "query")
 
-    def contains(self, ldap_entry, mapping):
+    def _contains(self, ldap_entry, mapping):
         return mapping.ldap_attribute in ldap_entry[1] and mapping.value in map(
             lambda x: x.decode(), ldap_entry[1][mapping.ldap_attribute]
         )
 
-    def equals(self, ldap_entry, mapping):
+    def _equals(self, ldap_entry, mapping):
         return mapping.ldap_attribute in ldap_entry[1] and mapping.value == str(
             list(map(lambda x: x.decode(), ldap_entry[1][mapping.ldap_attribute]))
         )
 
-    def query(self, ldap_entry, mapping):
+    def _query(self, ldap_entry, mapping):
         query_string = Template(mapping.value).safe_substitute(
             {attr: ldap_entry[1][attr][0].decode() for attr in ldap_entry[1]}
         )

--- a/users_ldap_groups/models/res_company_ldap_operator.py
+++ b/users_ldap_groups/models/res_company_ldap_operator.py
@@ -17,7 +17,7 @@ class ResCompanyLdapOperator(models.AbstractModel):
 
     @api.model
     def operators(self):
-        """Return names of function to call on this model as operator"""
+        """Return names (without '_') of function to call on this model as operator"""
         return ("contains", "equals", "query")
 
     def _contains(self, ldap_entry, mapping):


### PR DESCRIPTION
Fix https://github.com/OCA/server-auth/issues/617

res.company.ldap.operator operators should be private methods; public methods allow arbitrary LDAP queries via JSON-API