### PR TITLE
[16.0][FIX] vault: Stop propagation when clicking "enter"

### DIFF
--- a/vault/static/src/common/utils.esm.js
+++ b/vault/static/src/common/utils.esm.js
@@ -191,7 +191,8 @@ function askpass(title, options = {}) {
                 {
                     text: _t("Enter"),
                     classes: "btn-primary",
-                    click: async function () {
+                    click: async function (ev) {
+                        ev.stopPropagation();
                         const password = this.$("#password").val();
                         const keyfile = this.$("#keyfile")[0].files[0];
 
@@ -222,7 +223,8 @@ function askpass(title, options = {}) {
                 },
                 {
                     text: _t("Cancel"),
-                    click: function () {
+                    click: function (ev) {
+                        ev.stopPropagation();
                         dialog.close();
                         reject(_t("Cancelled"));
                     },


### PR DESCRIPTION
Before this changes, when the password was required some other click events can be thrown.

To reproduce this problem:

1. Create a vault with an entry and a field
2. Clean session coockies
3. Without entering the private key, go to try change the field value
4. Set the private key and press enter

The system will ask for the private key once again.

cc @Tecnativa TT49556

ping @fkantelberg @pedrobaeza 