### PR TITLE
[16.0][IMP] vault: Update value when input is decrypted

### DIFF
--- a/vault/static/src/backend/controller.esm.js
+++ b/vault/static/src/backend/controller.esm.js
@@ -374,6 +374,13 @@ patch(FormController.prototype, "vault", {
         return await _super(...arguments);
     },
 
+    async discard() {
+        const _super = this._super.bind(this);
+        if (this.model.root.resModel === "vault.entry")
+            this.model.env.bus.trigger("RELATIONAL_MODEL:ENCRYPT_FIELDS");
+        return await _super(...arguments);
+    },
+
     async beforeLeave() {
         const _super = this._super.bind(this);
         if (this.model.root.isDirty) await this._vaultAction();

--- a/vault/static/src/backend/fields/vault_field.esm.js
+++ b/vault/static/src/backend/fields/vault_field.esm.js
@@ -65,6 +65,10 @@ export default class VaultField extends VaultMixin(Component) {
         useBus(self.env.bus, "RELATIONAL_MODEL:NEED_LOCAL_CHANGES", (ev) =>
             ev.detail.proms.push(self.commitChanges())
         );
+        useBus(self.env.bus, "RELATIONAL_MODEL:ENCRYPT_FIELDS", () => {
+            this.state.decrypted = false;
+            this.showValue();
+        });
     }
 
     /**
@@ -174,6 +178,7 @@ export default class VaultField extends VaultMixin(Component) {
             const val = this.input.el.value || false;
             if (val !== (this.state.lastSetValue || false)) {
                 this.state.lastSetValue = this.input.el.value;
+                this.state.decryptedValue = this.input.el.value;
                 await this.storeValue(val);
                 this.props.setDirty(this.state.isDirty);
             }


### PR DESCRIPTION
Up until now, when a field was decrypted, making a change would cause it to be lost, which could confuse the user. After fixing this, it happened that discarding the changes made it seem like the change had not been discarded.

In this gif you will see what happen before this PR
![not updated](https://github.com/user-attachments/assets/52a6c353-3351-4669-b345-8ef3db3419ce)

The measure that has been taken is to, upon discarding, do as saving does: hide the value of the field, and the change remains in the input as long as it is not saved, discarded, or hidden.
![updated](https://github.com/user-attachments/assets/633f2f85-aed9-4cdf-bea8-13fc77164ef6)

cc @Tecnativa TT50258

ping @pedrobaeza @pilarvargas-tecnativa 