### PR TITLE
[15.0][IMP] auth_ldaps: Allow disabling LDAP ref-chasing

### DIFF
--- a/auth_ldaps/models/res_company_ldap.py
+++ b/auth_ldaps/models/res_company_ldap.py
@@ -34,7 +34,11 @@ class CompanyLDAP(models.Model):
         if conf["is_ssl"]:
             uri = "ldaps://%s:%d" % (conf["ldap_server"], conf["ldap_server_port"])
             connection = ldap.initialize(uri)
-            ldap_chase_ref_disabled = self.env['ir.config_parameter'].sudo().get_param('auth_ldap.disable_chase_ref')
+            ldap_chase_ref_disabled = (
+                self.env['ir.config_parameter']
+                .sudo()
+                .get_param('auth_ldap.disable_chase_ref')
+            )
             if str2bool(ldap_chase_ref_disabled):
                 connection.set_option(ldap.OPT_REFERRALS, ldap.OPT_OFF)
             if conf["skip_cert_validation"]:

--- a/auth_ldaps/models/res_company_ldap.py
+++ b/auth_ldaps/models/res_company_ldap.py
@@ -8,6 +8,7 @@ import logging
 import ldap
 
 from odoo import fields, models
+from odoo.tools.misc import str2bool
 
 _logger = logging.getLogger(__name__)
 
@@ -33,6 +34,9 @@ class CompanyLDAP(models.Model):
         if conf["is_ssl"]:
             uri = "ldaps://%s:%d" % (conf["ldap_server"], conf["ldap_server_port"])
             connection = ldap.initialize(uri)
+            ldap_chase_ref_disabled = self.env['ir.config_parameter'].sudo().get_param('auth_ldap.disable_chase_ref')
+            if str2bool(ldap_chase_ref_disabled):
+                connection.set_option(ldap.OPT_REFERRALS, ldap.OPT_OFF)
             if conf["skip_cert_validation"]:
                 connection.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_ALLOW)
                 # this creates a new tls context, which is required to apply

--- a/auth_ldaps/models/res_company_ldap.py
+++ b/auth_ldaps/models/res_company_ldap.py
@@ -37,7 +37,7 @@ class CompanyLDAP(models.Model):
             ldap_chase_ref_disabled = (
                 self.env['ir.config_parameter']
                 .sudo()
-                .get_param('auth_ldap.disable_chase_ref')
+                .get_param("auth_ldap.disable_chase_ref")
             )
             if str2bool(ldap_chase_ref_disabled):
                 connection.set_option(ldap.OPT_REFERRALS, ldap.OPT_OFF)

--- a/auth_ldaps/models/res_company_ldap.py
+++ b/auth_ldaps/models/res_company_ldap.py
@@ -35,7 +35,7 @@ class CompanyLDAP(models.Model):
             uri = "ldaps://%s:%d" % (conf["ldap_server"], conf["ldap_server_port"])
             connection = ldap.initialize(uri)
             ldap_chase_ref_disabled = (
-                self.env['ir.config_parameter']
+                self.env["ir.config_parameter"]
                 .sudo()
                 .get_param("auth_ldap.disable_chase_ref")
             )


### PR DESCRIPTION
This feature was added to the vanilla `auth_ldap` module [back in 15.0](https://github.com/odoo/odoo/commit/eb64ce68f23d8b62fb232b0c7102d31370f30cc6).

The current `_connect()` impl by `auth_ldaps` does _not_ check for this ICP, and so we have some feature disparity. I think probably noone has checked/noticed that this was added to the base LDAP module.

This should be forward-portable to 16.0.

Also will need to forward-port to 17.0 once #643 is done.