### PR TITLE
[16.0][FIX] vault_share: Button to share value not showed and not working

### DIFF
--- a/vault_share/static/src/backend/fields/vault_field.esm.js
+++ b/vault_share/static/src/backend/fields/vault_field.esm.js
@@ -11,18 +11,22 @@ import vault from "vault";
 
 // Extend the widget to share
 patch(VaultField.prototype, "vault_share", {
+    get shareButton() {
+        return this.props.value;
+    },
     /**
      * Share the value for an external user
      *
      * @private
      */
-    async _onShareValue() {
+    async _onShareValue(ev) {
+        ev.stopPropagation();
         const iv = await utils.generate_iv_base64();
         const pin = sh_utils.generate_pin(sh_utils.PinSize);
         const salt = utils.generate_bytes(utils.SaltLength).buffer;
         const key = await utils.derive_key(pin, salt, utils.Derive.iterations);
         const public_key = await vault.get_public_key();
-        const value = await this._decrypt(this.value);
+        const value = await this._decrypt(this.props.value);
 
         this.action.doAction({
             type: "ir.actions.act_window",


### PR DESCRIPTION
To show the button up, it is requiring a getter that is not defined on vault field. So the getter is added and make the button works correctly.

Before:
![image](https://github.com/user-attachments/assets/350908ef-e88b-4f8b-87b0-2fb876c6d2ad)

After:
![image](https://github.com/user-attachments/assets/4739eaab-a4a6-47fc-a049-fe571330f2c4)

Steps to reproduce the problem:

1. Go to Vault
2. Enter/Create a Vault
3. Press on entries
4. Access/Create a entry with a field

The button with external link is not showed

cc @Tecnativa TT50557

ping @pedrobaeza @chienandalu @fkantelberg 