### PR TITLE
[17.0][IMP] auth_oidc: add groups' handling

### DIFF
--- a/auth_oidc/__manifest__.py
+++ b/auth_oidc/__manifest__.py
@@ -16,6 +16,10 @@
     "summary": "Allow users to login through OpenID Connect Provider",
     "external_dependencies": {"python": ["python-jose"]},
     "depends": ["auth_oauth"],
-    "data": ["views/auth_oauth_provider.xml", "data/auth_oauth_data.xml"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/auth_oauth_provider.xml",
+        "data/auth_oauth_data.xml",
+    ],
     "demo": ["demo/local_keycloak.xml"],
 }

--- a/auth_oidc/demo/local_keycloak.xml
+++ b/auth_oidc/demo/local_keycloak.xml
@@ -37,9 +37,20 @@
         <field name="body">Log in with Microsoft</field>
         <field name="auth_link_params">{'prompt':'select_account'}</field>
     </record>
-    <record id="local_keycloak_group_line" model="auth.oauth.provider.group_line">
+    <record
+        id="local_keycloak_group_line_name_is_test"
+        model="auth.oauth.provider.group_line"
+    >
         <field name="provider_id" ref="local_keycloak" />
         <field name="group_id" ref="base.group_no_one" />
         <field name="expression">token['name'] == 'test'</field>
+    </record>
+    <record
+        id="local_keycloak_group_line_erp_manager_in_groups"
+        model="auth.oauth.provider.group_line"
+    >
+        <field name="provider_id" ref="local_keycloak" />
+        <field name="group_id" ref="base.group_erp_manager" />
+        <field name="expression">'erp_manager' in token['groups']</field>
     </record>
 </odoo>

--- a/auth_oidc/demo/local_keycloak.xml
+++ b/auth_oidc/demo/local_keycloak.xml
@@ -37,4 +37,9 @@
         <field name="body">Log in with Microsoft</field>
         <field name="auth_link_params">{'prompt':'select_account'}</field>
     </record>
+    <record id="local_keycloak_group_line" model="auth.oauth.provider.group_line">
+        <field name="provider_id" ref="local_keycloak" />
+        <field name="group_id" ref="base.group_no_one" />
+        <field name="expression">token['name'] == 'test'</field>
+    </record>
 </odoo>

--- a/auth_oidc/models/auth_oauth_provider.py
+++ b/auth_oidc/models/auth_oauth_provider.py
@@ -130,8 +130,12 @@ class AuthOauthProviderGroupLine(models.Model):
         for this in self:
             try:
                 this._eval_expression(self.env.user, {})
-            except (AttributeError, KeyError, NameError) as e:
-                raise exceptions.ValidationError("\n".join(e.args)) from e
+            except (AttributeError, KeyError, NameError, ValueError) as e:
+                # AttributeError: user object can be accessed via attributes: user.email
+                # KeyError: token is a dict of dicts
+                # NameError: only user and token can be used
+                # ValueError: for inexistant variables or attributes
+                raise exceptions.ValidationError(e) from e
 
     def _eval_expression(self, user, token):
         self.ensure_one()

--- a/auth_oidc/models/auth_oauth_provider.py
+++ b/auth_oidc/models/auth_oauth_provider.py
@@ -2,12 +2,13 @@
 # Copyright 2021 ACSONE SA/NV <https://acsone.eu>
 # License: AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
+import collections
 import logging
 import secrets
 
 import requests
 
-from odoo import fields, models, tools
+from odoo import api, exceptions, fields, models, tools
 
 try:
     from jose import jwt
@@ -51,6 +52,11 @@ class AuthOauthProvider(models.Model):
         "For example: {'prompt':'select_account'}"
     )
     end_session_endpoint = fields.Char(string="End Session URL")
+    group_line_ids = fields.One2many(
+        "auth.oauth.provider.group_line",
+        "provider_id",
+        string="Group mappings",
+    )
 
     @tools.ormcache("self.jwks_uri", "kid")
     def _get_keys(self, kid):
@@ -109,3 +115,36 @@ class AuthOauthProvider(models.Model):
         if error:
             raise error
         return {}
+
+
+class AuthOauthProviderGroupLine(models.Model):
+    _name = "auth.oauth.provider.group_line"
+
+    provider_id = fields.Many2one("auth.oauth.provider", required=True)
+    group_id = fields.Many2one("res.groups", required=True)
+    expression = fields.Char(required=True, help="Variables: user, token")
+
+    @api.constrains("expression")
+    def _check_expression(self):
+        for this in self:
+            try:
+                this._eval_expression(self.env.user, {})
+            except (AttributeError, KeyError, NameError) as e:
+                raise exceptions.ValidationError("\n".join(e.args))
+
+    def _eval_expression(self, user, token):
+        self.ensure_one()
+
+        class Defaultdict2(collections.defaultdict):
+            """Class keeping yielding defaultdicts"""
+
+            def __init__(self, *args, **kwargs):
+                super().__init__(Defaultdict2, *args, **kwargs)
+
+        return tools.safe_eval.safe_eval(
+            self.expression,
+            {
+                "user": user,
+                "token": Defaultdict2(token),
+            },
+        )

--- a/auth_oidc/models/auth_oauth_provider.py
+++ b/auth_oidc/models/auth_oauth_provider.py
@@ -119,6 +119,7 @@ class AuthOauthProvider(models.Model):
 
 class AuthOauthProviderGroupLine(models.Model):
     _name = "auth.oauth.provider.group_line"
+    _description = "OAuth mapping between an Odoo group and an expression"
 
     provider_id = fields.Many2one("auth.oauth.provider", required=True)
     group_id = fields.Many2one("res.groups", required=True)

--- a/auth_oidc/models/auth_oauth_provider.py
+++ b/auth_oidc/models/auth_oauth_provider.py
@@ -131,7 +131,7 @@ class AuthOauthProviderGroupLine(models.Model):
             try:
                 this._eval_expression(self.env.user, {})
             except (AttributeError, KeyError, NameError) as e:
-                raise exceptions.ValidationError("\n".join(e.args))
+                raise exceptions.ValidationError("\n".join(e.args)) from e
 
     def _eval_expression(self, user, token):
         self.ensure_one()

--- a/auth_oidc/models/res_users.py
+++ b/auth_oidc/models/res_users.py
@@ -69,6 +69,7 @@ class ResUsers(models.Model):
             data = requests.get(
                 oauth_provider.data_endpoint,
                 headers={"Authorization": "Bearer %s" % access_token},
+                timeout=10,
             ).json()
             validation.update(data)
         # required check

--- a/auth_oidc/models/res_users.py
+++ b/auth_oidc/models/res_users.py
@@ -64,6 +64,12 @@ class ResUsers(models.Model):
             _logger.error("No id_token in response.")
             raise AccessDenied()
         validation = oauth_provider._parse_id_token(id_token, access_token)
+        if oauth_provider.data_endpoint:
+            data = requests.get(
+                oauth_provider.data_endpoint,
+                headers={"Authorization": "Bearer %s" % access_token},
+            ).json()
+            validation.update(data)
         # required check
         if "sub" in validation and "user_id" not in validation:
             # set user_id for auth_oauth, user_id is not an OpenID Connect standard
@@ -80,3 +86,22 @@ class ResUsers(models.Model):
             raise AccessDenied()
         # return user credentials
         return (self.env.cr.dbname, login, access_token)
+
+    @api.model
+    def _auth_oauth_signin(self, provider, validation, params):
+        login = super()._auth_oauth_signin(provider, validation, params)
+        user = self.search([("login", "=", login)])
+        if user:
+            group_updates = []
+            for group_line in (
+                self.env["auth.oauth.provider"].browse(provider).group_line_ids
+            ):
+                if group_line._eval_expression(user, validation):
+                    if group_line.group_id not in user.groups_id:
+                        group_updates.append((4, group_line.group_id.id))
+                else:
+                    if group_line.group_id in user.groups_id:
+                        group_updates.append((3, group_line.group_id.id))
+            if group_updates:
+                user.write({"groups_id": group_updates})
+        return login

--- a/auth_oidc/models/res_users.py
+++ b/auth_oidc/models/res_users.py
@@ -8,6 +8,7 @@ import requests
 
 from odoo import api, models
 from odoo.exceptions import AccessDenied
+from odoo.fields import Command
 from odoo.http import request
 
 _logger = logging.getLogger(__name__)
@@ -98,10 +99,10 @@ class ResUsers(models.Model):
             ):
                 if group_line._eval_expression(user, validation):
                     if group_line.group_id not in user.groups_id:
-                        group_updates.append((4, group_line.group_id.id))
+                        group_updates.append(Command.link(group_line.group_id.id))
                 else:
                     if group_line.group_id in user.groups_id:
-                        group_updates.append((3, group_line.group_id.id))
+                        group_updates.append(Command.unlink(group_line.group_id.id))
             if group_updates:
                 user.write({"groups_id": group_updates})
         return login

--- a/auth_oidc/models/res_users.py
+++ b/auth_oidc/models/res_users.py
@@ -64,14 +64,20 @@ class ResUsers(models.Model):
         if not id_token:
             _logger.error("No id_token in response.")
             raise AccessDenied()
+
+        # Parse the ID token
         validation = oauth_provider._parse_id_token(id_token, access_token)
+
+        # Use the access_token to fetch the data_endpoint (userinfo)
         if oauth_provider.data_endpoint:
-            data = requests.get(
+            response = requests.get(
                 oauth_provider.data_endpoint,
                 headers={"Authorization": "Bearer %s" % access_token},
                 timeout=10,
-            ).json()
-            validation.update(data)
+            )
+            if response.ok:  # nb: could be a successful failure
+                validation.update(response.json())
+
         # required check
         if "sub" in validation and "user_id" not in validation:
             # set user_id for auth_oauth, user_id is not an OpenID Connect standard

--- a/auth_oidc/security/ir.model.access.csv
+++ b/auth_oidc/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_auth_oauth_provider_group_line,auth_oauth_provider,model_auth_oauth_provider_group_line,base.group_system,1,1,1,1

--- a/auth_oidc/tests/test_auth_oidc_auth_code.py
+++ b/auth_oidc/tests/test_auth_oidc_auth_code.py
@@ -317,3 +317,9 @@ class TestAuthOIDCAuthorizationCodeFlow(common.HttpCase):
             )
         self.assertEqual(token, "122/3")
         self.assertEqual(login, user.login)
+
+    def test_group_expression(self):
+        """Test that group expressions evaluate correctly"""
+        group_line = self.env.ref("auth_oidc.local_keycloak").group_line_ids[:1]
+        group_line.expression = 'token["test"]["test"] == 1'
+        self.assertFalse(group_line._eval_expression(self.env.user, {}))

--- a/auth_oidc/tests/test_auth_oidc_auth_code.py
+++ b/auth_oidc/tests/test_auth_oidc_auth_code.py
@@ -13,7 +13,7 @@ from jose.exceptions import JWTError
 from jose.utils import long_to_base64
 
 import odoo
-from odoo.exceptions import AccessDenied
+from odoo.exceptions import AccessDenied, ValidationError
 from odoo.tests import common
 
 from odoo.addons.website.tools import MockRequest as _MockRequest
@@ -339,4 +339,27 @@ class TestAuthOIDCAuthorizationCodeFlow(common.HttpCase):
         )
         self.assertFalse(
             group_line._eval_expression(self.env.user, {"groups": ["group-c"]})
+        )
+
+    def test_group_expression_with_inexistant_variable(self):
+        """Test that group expression with inexistant variable fails"""
+        group_line = self.env.ref("auth_oidc.local_keycloak").group_line_ids[:1]
+
+        with self.assertRaises(ValidationError):
+            group_line.expression = "inexistant_variable"
+
+    def test_group_expression_with_inexistant_attribute(self):
+        """Test that group expression with inexistant attribute (on user) fails"""
+        group_line = self.env.ref("auth_oidc.local_keycloak").group_line_ids[:1]
+
+        with self.assertRaises(ValidationError):
+            group_line.expression = "user.not_an_attribute"
+
+    def test_realistic_group_expression(self):
+        """Test that group expression with inexistant attribute (on user) fails"""
+        group_line = self.env.ref("auth_oidc.local_keycloak").group_line_ids[:1]
+
+        group_line.expression = "user.email == token['mail']"
+        self.assertTrue(
+            group_line._eval_expression(self.env.user, {"mail": self.env.user.email})
         )

--- a/auth_oidc/tests/test_auth_oidc_auth_code.py
+++ b/auth_oidc/tests/test_auth_oidc_auth_code.py
@@ -21,6 +21,7 @@ from odoo.addons.website.tools import MockRequest as _MockRequest
 from ..controllers.main import OpenIDLogin
 
 BASE_URL = "http://localhost:%s" % odoo.tools.config["http_port"]
+KEYCLOAK_URL = "http://localhost:8080"
 
 
 @contextlib.contextmanager
@@ -119,7 +120,7 @@ class TestAuthOIDCAuthorizationCodeFlow(common.HttpCase):
             id_token_headers = {"kid": "the_key_id"}
         responses.add(
             responses.POST,
-            "http://localhost:8080/auth/realms/master/protocol/openid-connect/token",
+            KEYCLOAK_URL + "/auth/realms/master/protocol/openid-connect/token",
             json={
                 "access_token": access_token,
                 "id_token": jwt.encode(
@@ -137,7 +138,7 @@ class TestAuthOIDCAuthorizationCodeFlow(common.HttpCase):
                 keys = [{"keys": [self.rsa_key_public_pem]}]
         responses.add(
             responses.GET,
-            "http://localhost:8080/auth/realms/master/protocol/openid-connect/certs",
+            KEYCLOAK_URL + "/auth/realms/master/protocol/openid-connect/certs",
             json={"keys": keys},
         )
 

--- a/auth_oidc/tests/test_auth_oidc_auth_code.py
+++ b/auth_oidc/tests/test_auth_oidc_auth_code.py
@@ -70,7 +70,7 @@ class TestAuthOIDCAuthorizationCodeFlow(common.HttpCase):
 
     def setUp(self):
         super().setUp()
-        # search our test provider and bind the demo user to it
+        # search our only test provider
         self.provider_rec = self.env["auth.oauth.provider"].search(
             [("name", "=", "keycloak:8080 on localhost")]
         )
@@ -107,6 +107,7 @@ class TestAuthOIDCAuthorizationCodeFlow(common.HttpCase):
             self.assertEqual(params["prompt"], ["select_account"])
 
     def _prepare_login_test_user(self):
+        # bind the demo user to our test provider it
         user = self.env.ref("base.user_demo")
         user.write({"oauth_provider_id": self.provider_rec.id, "oauth_uid": user.login})
         return user

--- a/auth_oidc/tests/test_auth_oidc_auth_code.py
+++ b/auth_oidc/tests/test_auth_oidc_auth_code.py
@@ -14,6 +14,7 @@ from jose.utils import long_to_base64
 
 import odoo
 from odoo.exceptions import AccessDenied, ValidationError
+from odoo.fields import Command
 from odoo.tests import common
 
 from odoo.addons.website.tools import MockRequest as _MockRequest
@@ -157,6 +158,44 @@ class TestAuthOIDCAuthorizationCodeFlow(common.HttpCase):
             )
         self.assertEqual(token, "42")
         self.assertEqual(login, user.login)
+
+    @responses.activate
+    def test_manager_login(self):
+        """Test that login works and assigns the user to a manager group"""
+        user = self._prepare_login_test_user()
+        self._prepare_login_test_responses(
+            id_token_body={"user_id": user.login, "groups": ["erp_manager"]}
+        )
+
+        params = {"state": json.dumps({})}
+        with MockRequest(self.env):
+            db, login, token = self.env["res.users"].auth_oauth(
+                self.provider_rec.id,
+                params,
+            )
+        self.assertTrue(user.has_group("base.group_erp_manager"))
+
+    @responses.activate
+    def test_ex_manager_login(self):
+        """Test that login works and de-assigns the user from a manager group"""
+        user = self._prepare_login_test_user()
+        # Make them a manager
+        user.write(
+            {"groups_id": [Command.link(self.env.ref("base.group_erp_manager").id)]}
+        )
+        self.assertTrue(user.has_group("base.group_erp_manager"))
+
+        self._prepare_login_test_responses(
+            id_token_body={"user_id": user.login, "groups": ["not_erp_manager"]}
+        )
+
+        params = {"state": json.dumps({})}
+        with MockRequest(self.env):
+            db, login, token = self.env["res.users"].auth_oauth(
+                self.provider_rec.id,
+                params,
+            )
+        self.assertFalse(user.has_group("base.group_erp_manager"))
 
     @responses.activate
     def test_login_without_kid(self):

--- a/auth_oidc/tests/test_auth_oidc_auth_code.py
+++ b/auth_oidc/tests/test_auth_oidc_auth_code.py
@@ -320,8 +320,23 @@ class TestAuthOIDCAuthorizationCodeFlow(common.HttpCase):
         self.assertEqual(token, "122/3")
         self.assertEqual(login, user.login)
 
-    def test_group_expression(self):
-        """Test that group expressions evaluate correctly"""
+    def test_group_expression_empty_token(self):
+        """Test that group expression with an empty token evaluate correctly"""
         group_line = self.env.ref("auth_oidc.local_keycloak").group_line_ids[:1]
         group_line.expression = 'token["test"]["test"] == 1'
         self.assertFalse(group_line._eval_expression(self.env.user, {}))
+
+    def test_group_expressions_with_token(self):
+        """Test that group expression with token with groups evaluate correctly"""
+        group_line = self.env.ref("auth_oidc.local_keycloak").group_line_ids[:1]
+
+        group_line.expression = "'group-a' in token['groups']"
+        self.assertFalse(group_line._eval_expression(self.env.user, {}))
+        self.assertTrue(
+            group_line._eval_expression(
+                self.env.user, {"groups": ["group-a", "group-b"]}
+            )
+        )
+        self.assertFalse(
+            group_line._eval_expression(self.env.user, {"groups": ["group-c"]})
+        )

--- a/auth_oidc/views/auth_oauth_provider.xml
+++ b/auth_oidc/views/auth_oauth_provider.xml
@@ -23,6 +23,16 @@
             <field name="auth_endpoint" position="after">
                 <field name="auth_link_params" />
             </field>
+            <xpath expr="//sheet/group[last()]" position="after">
+                <group name="mappings">
+                    <field name="group_line_ids">
+                        <tree editable="bottom">
+                            <field name="group_id" />
+                            <field name="expression" />
+                        </tree>
+                    </field>
+                </group>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
This allows groups' handling via a token's attributes as passed by either a Keycloak or a Gitlab instance serving as IdP.

* This is the 17.0-version of #350, then #372 , by @26houseRobot and @hbrunn , with just minor fixes

@sbidoul : I'd be happy to make any necessary changes!