### PR TITLE
[FIX] auth_session_timeout: add /longpolling/im_status as ignored url

### DIFF
--- a/auth_session_timeout/__manifest__.py
+++ b/auth_session_timeout/__manifest__.py
@@ -13,7 +13,7 @@
     "maintainer": "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/server-auth",
     "category": "Tools",
-    "version": "15.0.1.0.0",
+    "version": "15.0.1.0.1",
     "license": "AGPL-3",
     "data": ["data/ir_config_parameter_data.xml"],
     "installable": True,

--- a/auth_session_timeout/data/ir_config_parameter_data.xml
+++ b/auth_session_timeout/data/ir_config_parameter_data.xml
@@ -9,6 +9,8 @@
     </record>
     <record id="inactive_session_time_out_ignored_url" model="ir.config_parameter">
         <field name="key">inactive_session_time_out_ignored_url</field>
-        <field name="value">/calendar/notify,/longpolling/poll</field>
+        <field
+            name="value"
+        >/calendar/notify,/longpolling/poll,/longpolling/im_status</field>
     </record>
 </odoo>

--- a/auth_session_timeout/migrations/15.0.1.0.1/post-migration.py
+++ b/auth_session_timeout/migrations/15.0.1.0.1/post-migration.py
@@ -1,0 +1,28 @@
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    add_controller_to_parameter(cr)
+
+
+def add_controller_to_parameter(cr):
+    """Add /longpolling/im_status because it is executed several times (every 50 seconds)"""
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    new_url = "/longpolling/im_status"
+    ignored_path_key = "inactive_session_time_out_ignored_url"
+    param = env["ir.config_parameter"]
+    old_value = param.get_param(ignored_path_key, "")
+    if new_url in old_value:
+        _logger.info(
+            "%s is included in the parameter %s already.", new_url, ignored_path_key
+        )
+        return
+    new_value = "%s,%s" % (old_value, new_url)
+    param.set_param(ignored_path_key, new_value)
+    _logger.info(
+        "%s was added to the parameter %s successfully.", new_url, ignored_path_key
+    )


### PR DESCRIPTION
auth_session_timeout [1] uses the time of the modification of the session file to calculate the time of inactivity, but any edition in the session file will change the time of modification of the file and cause inexact time of inactivity.

The controller /longpolling/im_status is called several times (every 50 seconds) [2][3], so it is required taking it into account to avoid modifying the time of modification of the session file, so it is required adding /longpolling/im_status as a ignored url [4][5].

References:
- [1] https://github.com/Oca/server-auth/blob/1db10f29/auth_session_timeout/models/res_users.py#L73
- [2] https://github.com/odoo/odoo/blob/e5b67f9c/addons/mail/static/src/models/partner/partner.js#L395
- [3] https://github.com/odoo/odoo/blob/e5b67f9c/addons/mail/static/src/models/partner/partner.js#L407
- [4] https://github.com/Oca/server-auth/blob/1db10f29/auth_session_timeout/data/ir_config_parameter_data.xml#L12
- [5] https://github.com/Oca/server-auth/blob/1db10f29/auth_session_timeout/models/res_users.py#L93

![Screenshot from 2024-09-11 13-02-20](https://github.com/user-attachments/assets/46d30775-dc3b-4736-8179-23281e7d7676)
