### PR TITLE
[FIX] password_security: Fix reset password when user doesn't have password_write_date value.

### DIFF
--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -144,6 +144,8 @@ class ResUsers(models.Model):
             if pass_min <= 0:
                 continue
             write_date = user.password_write_date
+            if not write_date:
+                continue
             delta = timedelta(hours=pass_min)
             if write_date + delta > datetime.now():
                 raise UserError(


### PR DESCRIPTION
[FIX] password_security: Fix reset password when user doesn't have password_write_date value.

It happens that when you install the module, all the users that previously existed before that won't have a value set for the new field password_write_date. And when the validation of minimal hours has passed between the last password write date and now is done, it gets an error of unsupported operands between a bool and timedelta. With this change, it won't be necessary to validate the last password date if it's the first time reseting password, and when the password is changed it will correctly save the value on password_write_date and will be working normally afterwards.

![image](https://github.com/user-attachments/assets/d9fd6c09-6ddc-4652-99ad-51b4efbd8a03)
