### PR TITLE
[16.0][FIX] password_security: update password_write_date on copy

### DIFF
--- a/password_security/controllers/main.py
+++ b/password_security/controllers/main.py
@@ -17,7 +17,13 @@ _logger = logging.getLogger(__name__)
 class PasswordSecurityHome(AuthSignupHome):
     def do_signup(self, qcontext):
         password = qcontext.get("password")
-        user = request.env.user
+        # If 2FA is activated, request.env.user is not updated to the logged-in user
+        # at this point. In order to do _check_password on the correct user we
+        # search by login.
+        user = (
+            request.env.user.search([("login", "=", qcontext.get("login"))])
+            or request.env.user
+        )
         user._check_password(password)
         return super(PasswordSecurityHome, self).do_signup(qcontext)
 

--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -18,7 +18,7 @@ class ResUsers(models.Model):
     _inherit = "res.users"
 
     password_write_date = fields.Datetime(
-        "Last password update", default=fields.Datetime.now, readonly=True
+        "Last password update", default=fields.Datetime.now, readonly=True, copy=False
     )
     password_history_ids = fields.One2many(
         string="Password History",

--- a/password_security/tests/test_signup.py
+++ b/password_security/tests/test_signup.py
@@ -4,6 +4,7 @@
 
 from unittest import mock
 
+from freezegun import freeze_time
 from requests.exceptions import HTTPError
 
 from odoo import http
@@ -82,7 +83,8 @@ class TestPasswordSecuritySignup(HttpCase):
 
         # Stronger password: no error raised
         vals["password"] = "asdQWE12345_3"
-        login, pwd = self.env["res.users"].signup(vals)
+        with freeze_time("2020-01-01"):
+            login, pwd = self.env["res.users"].signup(vals)
 
         # check created user
         created_user = self.env["res.users"].search([("login", "=", "test_user")])
@@ -159,4 +161,24 @@ class TestPasswordSecuritySignup(HttpCase):
         self.assertIn("Content-Security-Policy", response.headers)
         self.assertEqual(
             response.headers["Content-Security-Policy"], "frame-ancestors 'self'"
+        )
+
+    def test_07_cloned_user_password_write_date(self):
+        """Users that are cloned should have their password_write_date updated"""
+        partner = self.env["res.partner"].create({"name": "test partner"})
+        vals = {
+            "name": "Test User",
+            "login": "test_user",
+            "email": "test_user@odoo.com",
+            "password": "Test_user_password123$",
+            "partner_id": partner.id,
+        }
+        with freeze_time("2020-01-01"):
+            self.env["res.users"].signup(vals)
+
+        original_user = self.env["res.users"].search([("login", "=", "test_user")])
+        copied_user = original_user.copy()
+
+        self.assertTrue(
+            copied_user.password_write_date > original_user.password_write_date
         )


### PR DESCRIPTION
Sometimes users are created from a template user via a `copy()`.
This has the issue that a password is passed via the `vals` of the copy
and therefore never seen by the `write()` function.

As a result, the `password_write_date` field is left to the value of the
template, which is either outdated or null.

A concrete bug that resulted from this is that newly created users were
asked to renew their password on their very first login.

---

This commit reapplies the same logic of the `write()` method to the
`copy()` method as well.

It also changes the unit test test_03_create_user_signup to create the
user at some time in the past so that
```python
assertNotEqual(password_write_date, created_user.password_write_date)
```
makes sense.

Finally it fixes the do_signup method to user the current user's
password otherwise the password_write_date will be overwritten even when
inputting invalid passwords