### PR TITLE
[FIX][14.0] auth_saml: Add FOR NO KEY UPDATE NOWAIT clause to SAML provider query

### DIFF
--- a/auth_saml/models/auth_saml_provider.py
+++ b/auth_saml/models/auth_saml_provider.py
@@ -308,6 +308,14 @@ class AuthSamlProvider(models.Model):
         except SignatureError:
             # we have a metadata url: try to refresh the metadata document
             if self.idp_metadata_url:
+                self.env.cr.execute(
+                    """
+                    SELECT id, idp_metadata
+                    FROM auth_saml_provider
+                    WHERE id=%s FOR NO KEY UPDATE NOWAIT
+                    """,
+                    (self.id,),
+                )
                 self.action_refresh_metadata_from_url()
                 # retry: if it fails again, we let the exception flow
                 client = self._get_client_for_provider(base_url)
@@ -424,11 +432,6 @@ class AuthSamlProvider(models.Model):
 
         # lock the records we might update, so that multiple simultaneous login
         # attempts will not cause concurrent updates
-        provider_ids = tuple(providers_to_update.keys())
-        self.env.cr.execute(
-            "SELECT id FROM auth_saml_provider WHERE id in %s FOR UPDATE",
-            (tuple(provider_ids),),
-        )
         updated = False
         for provider in providers:
             if provider.id in providers_to_update:


### PR DESCRIPTION
auth_saml: Add FOR NO KEY UPDATE NOWAIT clause to SAML provider query
- Enhance concurrency handling when fetching SAML provider data
- Prevent potential deadlocks by using NOWAIT
- Ensure data consistency during high-traffic scenarios

Previous attempt using the locking mechanisms

```
self.env.cr.execute(
    "SELECT id FROM auth_saml_provider WHERE id in %s FOR UPDATE",
    (tuple(provider_ids),),
 )
```

led to increased latency and deadlocks under high load.

We experienced race conditions where two simultaneous login
attempts triggered parallel updates of the idp_metadata, leading to unreleased locks.

The FOR NO KEY UPDATE NOWAIT clause addresses this issue by:
1. A weaker form of row-level locking compared to FOR UPDATE. It allows concurrent INSERT operations on child tables that reference the locked row, but prevents UPDATE and DELETE operations on the locked row
2. Failing fast if the lock cannot be acquired (NOWAIT)
3. Ensuring that only one transaction can update the idp_metadata at a time

[Offical Potsgresql documentation 
](https://www.postgresql.org/docs/current/explicit-locking.html)
> FOR NO KEY UPDATE
> Behaves similarly to FOR UPDATE, except that the lock acquired is weaker: this lock will not block SELECT FOR KEY SHARE commands that attempt to acquire a lock on the same rows. This lock mode is also acquired by any UPDATE that does not acquire a FOR UPDATE lock.