### PR TITLE
[17.0][IMP] auth_saml: only write value that changes

### DIFF
--- a/auth_saml/readme/HISTORY.md
+++ b/auth_saml/readme/HISTORY.md
@@ -1,3 +1,9 @@
-## 16.0.1.0.0
+## 17.0.1.1.0
 
-Initial migration for 16.0.
+When using attribute mapping, only write value that changes.
+No writing the value systematically avoids getting security mail on login/email
+when there is no real change.
+
+## 17.0.1.0.0
+
+Initial migration for 17.0.


### PR DESCRIPTION
When using mapping, not writing the value systematically avoids getting security mail on login/email changes when there is no change. Also use SQL for blanking passwords avoids the security update mails.