### PR TITLE
[IMP] impersonate_login: Restrict Admin settings impersonation

### DIFF
--- a/impersonate_login/README.rst
+++ b/impersonate_login/README.rst
@@ -40,7 +40,10 @@ following measures are in place:
 -  Mails and messages are sent from the original user.
 -  Impersonated logins are logged and can be consulted through the
    Settings -> Technical menu.
--
+- To prevent users with "Administration: Settings" rights from being impersonated,
+   enable the restrict_impersonate_admin_settings field in the settings.
+   This will restrict the ability to impersonate users with administrative
+   access to the settings.
 
 There is an alternative module to allow logins as another user
 (auth_admin_passkey), but it does not support these security mechanisms.
@@ -81,6 +84,8 @@ Contributors
 - Kévin Roche <kevin.roche@akretion.com>
 - [360ERP](https://www.360erp.com):
   - Andrea Stirpe
+- `Ooops404 <https://www.ooops404.com/>`_:
+  - Eduard Brahas <eduard@ooops404.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/impersonate_login/__manifest__.py
+++ b/impersonate_login/__manifest__.py
@@ -21,6 +21,7 @@
         "views/assets.xml",
         "views/res_users.xml",
         "views/impersonate_log.xml",
+        "views/res_config_settings.xml",
         "security/group.xml",
         "security/ir.model.access.csv",
     ],

--- a/impersonate_login/models/__init__.py
+++ b/impersonate_login/models/__init__.py
@@ -4,3 +4,4 @@ from . import mail_thread
 from . import mail_message
 from . import impersonate_log
 from . import model
+from . import res_config_settings

--- a/impersonate_login/models/res_config_settings.py
+++ b/impersonate_login/models/res_config_settings.py
@@ -1,0 +1,13 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    restrict_impersonate_admin_settings = fields.Boolean(
+        string="Restrict Impersonation of 'Administration: Settings' Users",
+        config_parameter="impersonate_login.restrict_impersonate_admin_settings",
+        help="If enabled, users with the 'Administration: Settings' access right"
+        " cannot be impersonated.",
+        default=False,
+    )

--- a/impersonate_login/models/res_users.py
+++ b/impersonate_login/models/res_users.py
@@ -24,6 +24,22 @@ class Users(models.Model):
 
     def impersonate_login(self):
         if request:
+
+            config_restrict = (
+                self.env["ir.config_parameter"]
+                .sudo()
+                .get_param("impersonate_login.restrict_impersonate_admin_settings")
+            )
+            if config_restrict:
+                admin_settings_group = self.env.ref("base.group_system")
+                if admin_settings_group in self.groups_id:
+                    raise UserError(
+                        _(
+                            "You cannot impersonate users with"
+                            " 'Administration: Settings' access rights."
+                        )
+                    )
+
             if request.session.impersonate_from_uid:
                 if self.id == request.session.impersonate_from_uid:
                     return self.back_to_origin_login()

--- a/impersonate_login/readme/CONTRIBUTORS.rst
+++ b/impersonate_login/readme/CONTRIBUTORS.rst
@@ -1,3 +1,5 @@
 - Kévin Roche <kevin.roche@akretion.com>
 - [360ERP](https://www.360erp.com):
   - Andrea Stirpe
+- `Ooops404 <https://www.ooops404.com/>`_:
+  - Eduard Brahas <eduard@ooops404.com>

--- a/impersonate_login/readme/DESCRIPTION.rst
+++ b/impersonate_login/readme/DESCRIPTION.rst
@@ -10,7 +10,10 @@ following measures are in place:
 -  Mails and messages are sent from the original user.
 -  Impersonated logins are logged and can be consulted through the
    Settings -> Technical menu.
--
+- To prevent users with "Administration: Settings" rights from being impersonated,
+   enable the restrict_impersonate_admin_settings field in the settings.
+   This will restrict the ability to impersonate users with administrative
+   access to the settings.
 
 There is an alternative module to allow logins as another user
 (auth_admin_passkey), but it does not support these security mechanisms.

--- a/impersonate_login/static/description/index.html
+++ b/impersonate_login/static/description/index.html
@@ -381,7 +381,13 @@ another user.</li>
 <li>Mails and messages are sent from the original user.</li>
 <li>Impersonated logins are logged and can be consulted through the
 Settings -&gt; Technical menu.</li>
-<li></li>
+<li><dl class="first docutils">
+<dt>To prevent users with “Administration: Settings” rights from being impersonated,</dt>
+<dd>enable the restrict_impersonate_admin_settings field in the settings.
+This will restrict the ability to impersonate users with administrative
+access to the settings.</dd>
+</dl>
+</li>
 </ul>
 <p>There is an alternative module to allow logins as another user
 (auth_admin_passkey), but it does not support these security mechanisms.</p>
@@ -426,6 +432,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Kévin Roche &lt;<a class="reference external" href="mailto:kevin.roche&#64;akretion.com">kevin.roche&#64;akretion.com</a>&gt;</li>
 <li>[360ERP](<a class="reference external" href="https://www.360erp.com">https://www.360erp.com</a>):
 - Andrea Stirpe</li>
+<li><a class="reference external" href="https://www.ooops404.com/">Ooops404</a>:
+- Eduard Brahas &lt;<a class="reference external" href="mailto:eduard&#64;ooops404.com">eduard&#64;ooops404.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/impersonate_login/views/res_config_settings.xml
+++ b/impersonate_login/views/res_config_settings.xml
@@ -1,0 +1,33 @@
+<odoo>
+    <record id="view_res_config_settings_impersonate" model="ir.ui.view">
+        <field name="name">res.config.settings.impersonate</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="base_setup.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='invite_users']" position="after">
+                <div id="impersonate_login">
+                    <h2>Impersonation Login</h2>
+                    <div
+                        class="row mt16 o_settings_container"
+                        name="impersonate_login_settings_container"
+                    >
+                        <div
+                            class="col-12 col-lg-6 o_setting_box"
+                            id="impersonate_login_settings"
+                        >
+                            <div class="o_setting_right_pane">
+                                <label for="restrict_impersonate_admin_settings">
+                                    Restrict Impersonation Login
+                                </label>
+                                <field
+                                    name="restrict_impersonate_admin_settings"
+                                    string="Restrict Impersonation of 'Administration: Settings' Users"
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This PR adds a configuration setting (`restrict_impersonate_admin_settings`) to exclude users with "Administration: Settings" rights to be impersonated. When enabled, only non-administrative users can be impersonated.