### PR TITLE
[16.0][FIX] users_ldap_populate: get additional operational attributes

### DIFF
--- a/users_ldap_populate/models/users_ldap.py
+++ b/users_ldap_populate/models/users_ldap.py
@@ -125,7 +125,11 @@ class CompanyLDAP(models.Model):
         ldap_binddn = conf["ldap_binddn"] or ""
         conn.simple_bind_s(ldap_binddn, ldap_password)
         results = conn.search_st(
-            conf["ldap_base"], ldap.SCOPE_SUBTREE, ldap_filter, ['*', '+'], timeout=timeout
+            conf["ldap_base"],
+            ldap.SCOPE_SUBTREE,
+            ldap_filter,
+            ["*", "+"],
+            timeout=timeout,
         )
         conn.unbind()
         return results

--- a/users_ldap_populate/models/users_ldap.py
+++ b/users_ldap_populate/models/users_ldap.py
@@ -125,7 +125,7 @@ class CompanyLDAP(models.Model):
         ldap_binddn = conf["ldap_binddn"] or ""
         conn.simple_bind_s(ldap_binddn, ldap_password)
         results = conn.search_st(
-            conf["ldap_base"], ldap.SCOPE_SUBTREE, ldap_filter, None, timeout=timeout
+            conf["ldap_base"], ldap.SCOPE_SUBTREE, ldap_filter, ['*', '+'], timeout=timeout
         )
         conn.unbind()
         return results


### PR DESCRIPTION
When using users_ldap_populate together with the users_ldap_groups module to synchronize groups especially the memberOf attribute is typically not fetched from the LDAP server without specifying it. This commit fixes this by adding the ['*', '+'] attributes to the search_st call.