### PR TITLE
[17.0]  auth_session_timeout: Fix pre-migrate script

### DIFF
--- a/auth_session_timeout/migrations/17.0.1.0.0/pre-migration.py
+++ b/auth_session_timeout/migrations/17.0.1.0.0/pre-migration.py
@@ -1,9 +1,9 @@
-def migrate(env, version):
+def migrate(cr, version):
     """
     Updates the 'inactive_session_time_out_ignored_url' parameter
     in the 'ir_config_parameter' table during migration.
     """
-    env.cr.execute(
+    cr.execute(
         """
         UPDATE ir_config_parameter
         SET value = '/calendar/notify,/websocket'


### PR DESCRIPTION
The pre-migrate script should use cr instead of env as parameter. 