### PR TITLE
Update pre-migration.py

### DIFF
--- a/auth_session_timeout/migrations/17.0.1.0.0/pre-migration.py
+++ b/auth_session_timeout/migrations/17.0.1.0.0/pre-migration.py
@@ -1,9 +1,9 @@
-def migrate(env, version):
+def migrate(cr, version):
     """
     Updates the 'inactive_session_time_out_ignored_url' parameter
     in the 'ir_config_parameter' table during migration.
     """
-    env.cr.execute(
+    cr.execute(
         """
         UPDATE ir_config_parameter
         SET value = '/calendar/notify,/websocket'


### PR DESCRIPTION
First time contributor, hi 👋

Fixes runtime error due to invalid migration script.

Stacktrace:
```text
File "/oca/server-auth/auth_session_timeout/migrations/17.0.1.0.0/pre-migration.py", line 6, in migrate
    env.cr.execute(
    ^^^^^^
  File "/odoo/odoo/odoo/sql_db.py", line 494, in __getattr__
    return getattr(self._obj, name)
           ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'psycopg2.extensions.cursor' object has no attribute 'cr'
```