### PR TITLE
[18.0][IMP] auth_jwt drop audience required

### DIFF
--- a/auth_jwt/models/auth_jwt_validator.py
+++ b/auth_jwt/models/auth_jwt_validator.py
@@ -65,7 +65,7 @@ class AuthJwtValidator(models.Model):
         default="RS256",
     )
     audience = fields.Char(
-        required=True, help="Comma separated list of audiences, to validate aud."
+        required=False, help="Comma separated list of audiences, to validate aud."
     )
     issuer = fields.Char(required=True, help="To validate iss.")
     user_id_strategy = fields.Selection(
@@ -200,12 +200,11 @@ class AuthJwtValidator(models.Model):
                 key=key,
                 algorithms=[algorithm],
                 options=dict(
-                    require=["exp", "aud", "iss"],
+                    require=["exp", "iss"],
                     verify_exp=True,
-                    verify_aud=True,
                     verify_iss=True,
                 ),
-                audience=self.audience.split(","),
+                audience=(self.audience).split(",") if self.audience else None,
                 issuer=self.issuer,
             )
         except Exception as e:

--- a/auth_jwt/tests/test_auth_jwt.py
+++ b/auth_jwt/tests/test_auth_jwt.py
@@ -344,6 +344,11 @@ class TestAuthMethod(TransactionCase):
         with self.assertRaises(UnauthorizedInvalidToken):
             validator._decode(token)
 
+    def test_no_aud(self):
+        validator = self._create_validator("validator", audience=None)
+        token = self._create_token(audience=None)
+        validator._decode(token)
+
     def test_nbf(self):
         validator = self._create_validator("validator")
         token = self._create_token(nbf=time.time() - 60)


### PR DESCRIPTION
support simple jwt token issuer like AWS cognito using a pool_id in the certificate path to segment the resource group

ref: https://stackoverflow.com/questions/53148711/why-doesnt-amazon-cognito-return-an-audience-field-in-its-access-tokens

