### PR TITLE
[fix] totp wizard: force save token

### DIFF
--- a/auth_totp/wizards/res_users_authenticator_create.xml
+++ b/auth_totp/wizards/res_users_authenticator_create.xml
@@ -20,7 +20,7 @@
                     <group name="data">
                         <field name="name"/>
                         <field name="user_id"/>
-                        <field name="secret_key" readonly="1"/>
+                        <field name="secret_key" readonly="1" force_save="1"/>
                         <field name="qr_code_tag"/>
                         <field name="confirmation_code"/>
                     </group>


### PR DESCRIPTION
When the token field is readonly, it does not get sent in the button call, this causes the token to be regenerated sometimes. It is not consistent, at least when I tried this module now, sometimes it works, but most times it fails and a new token gets generated after the "Create" button is pressed