### PR TITLE
[FIX] auth_signup_verify_email: Use reCaptcha

### DIFF
--- a/auth_signup_verify_email/__manifest__.py
+++ b/auth_signup_verify_email/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Verify email at signup",
     "summary": "Force uninvited users to use a good email for signup",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "category": "Authentication",
     "website": "https://github.com/OCA/server-auth",
     "author": "Antiun Ingeniería S.L., "

--- a/auth_signup_verify_email/controllers/main.py
+++ b/auth_signup_verify_email/controllers/main.py
@@ -6,6 +6,7 @@ import logging
 from email_validator import EmailSyntaxError, EmailUndeliverableError, validate_email
 
 from odoo import _
+from odoo.exceptions import UserError
 from odoo.http import request, route
 
 from odoo.addons.auth_signup.controllers.main import AuthSignupHome
@@ -26,6 +27,8 @@ class SignupVerifyEmail(AuthSignupHome):
 
         # Check good format of e-mail
         try:
+            if not request.env["ir.http"]._verify_request_recaptcha_token("signup"):
+                raise UserError(_("Suspicious activity detected by Google reCaptcha."))
             validate_email(values.get("login", ""))
         except EmailSyntaxError as error:
             qcontext["error"] = getattr(

--- a/auth_signup_verify_email/tests/test_verify_email.py
+++ b/auth_signup_verify_email/tests/test_verify_email.py
@@ -11,6 +11,7 @@ except ImportError:
 from odoo.tests.common import HttpCase
 from odoo.tools.misc import mute_logger
 
+from odoo.addons.base.models import ir_http
 from odoo.addons.mail.models import mail_template
 
 
@@ -44,6 +45,15 @@ class UICase(HttpCase):
         self.data["login"] = "bad email"
         doc = self.html_doc(data=self.data)
         self.assertTrue(doc.xpath('//p[@class="alert alert-danger"]'))
+
+    def test_failed_recaptcha(self):
+        """Test rejection of failed reCaptcha."""
+        with patch.object(
+            ir_http.IrHttp, "_verify_request_recaptcha_token", return_value=False
+        ):
+            self.data["login"] = "contributors@odoo-community.org"
+            doc = self.html_doc(data=self.data)
+            self.assertTrue(doc.xpath('//p[@class="alert alert-danger"]'))
 
     @mute_logger("odoo.addons.auth_signup_verify_email.controllers.main")
     def test_good_email(self):


### PR DESCRIPTION
#774 
(previous pr with same changes #775 )

Fixes an issue when using the reCaptcha addon together with auth_signup_verify_email.
Currently, `passwordless_signup() `bypasses the reCaptcha check in the original `web_auth_signup() `method.

The root cause is that `_verify_request_recaptcha_token() `is supposed to remove the token from the request, but the same request is then used directly for user creation, resulting in: `ValueError: Invalid field 'recaptcha_token_response' on model 'res.users'`