### PR TITLE
[18.0][FIX] auth_saml: fix getting uid from authenticate return value

### DIFF
--- a/auth_saml/controllers/main.py
+++ b/auth_saml/controllers/main.py
@@ -246,8 +246,8 @@ class AuthSAMLController(http.Controller):
                 "token": credentials[2],
                 "type": "saml_token",
             }
-            pre_uid = request.session.authenticate(dbname, credentials_dict)
-            resp = request.redirect(_get_login_redirect_url(pre_uid, url), 303)
+            auth_info = request.session.authenticate(dbname, credentials_dict)
+            resp = request.redirect(_get_login_redirect_url(auth_info["uid"], url), 303)
             resp.autocorrect_location_header = False
             return resp
 

--- a/auth_saml/tests/test_pysaml.py
+++ b/auth_saml/tests/test_pysaml.py
@@ -628,6 +628,31 @@ class TestPySaml(HttpCase):
         self.assertEqual(signin_response.status_code, 303)
         self.assertIn("/?type=signup", signin_response.headers["Location"])
 
+    def test_signin_redirect_mfa(self):
+        """Test redirect to mfa url"""
+        self.add_provider_to_user()
+
+        redirect_url = self.saml_provider._get_auth_request({"a": "action"})
+        response = self.idp.fake_login(redirect_url)
+        unpacked_response = response._unpack()
+
+        for key in unpacked_response:
+            unpacked_response[key] = html.unescape(unpacked_response[key])
+        with patch.object(
+            self.env.registry["res.users"], "_mfa_url", return_value="/web/login/totp"
+        ):
+            response = self.url_open(
+                "/auth_saml/signin",
+                data=unpacked_response,
+                allow_redirects=True,
+                timeout=300,
+            )
+        self.assertTrue(response.ok)
+        self.assertEqual(
+            response.url,
+            self.base_url() + "/web/login/totp?redirect=%2F%23action%3Daction",
+        )
+
     def test_action_redirect(self):
         """Test that providing action will do correct redirect."""
         self.add_provider_to_user()


### PR DESCRIPTION
To reproduce: enable both saml and mfa.

Fixes
```
  File "/home/odoo/18.0/server-auth/auth_saml/controllers/main.py", line 251, in signin
    resp = request.redirect(_get_login_redirect_url(auth_info, url), 303)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/18.0/odoo/addons/web/controllers/utils.py", line 240, in _get_login_redirect_url
    url = request.env(user=uid)['res.users'].browse(uid)._mfa_url()
          ^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/18.0/odoo/odoo/api.py", line 644, in __call__
    uid = self.uid if user is None else int(user)
                                        ^^^^^^^^^
```

cf. https://github.com/odoo/odoo/blob/65704e58fda293af727f76d5c0741b135817db99/addons/web/controllers/home.py#L124-L126