### PR TITLE
[15.0][FIX] auth_saml: message indicates that a key is found incorrectly

### DIFF
--- a/auth_saml/models/auth_saml_provider.py
+++ b/auth_saml/models/auth_saml_provider.py
@@ -391,7 +391,7 @@ class AuthSamlProvider(models.Model):
         for attribute in self.attribute_mapping_ids:
             if attribute.attribute_name not in attrs:
                 _logger.debug(
-                    "SAML attribute '%s' found in response %s",
+                    "SAML attribute '%s' not found in response %s",
                     attribute.attribute_name,
                     attrs,
                 )


### PR DESCRIPTION
The message is incorrect, the log is done when the attribute key is not found.

Port of #758