### PR TITLE
[16][cross_connect_server]No invitation email for cross server created user

### DIFF
--- a/cross_connect_server/models/cross_connect_client.py
+++ b/cross_connect_server/models/cross_connect_client.py
@@ -83,7 +83,9 @@ class CrossConnectClient(models.Model):
         }
         # Create user if not exists
         if not user:
-            user = self.env["res.users"].create(vals)
+            user = (
+                self.env["res.users"].with_context(no_reset_password=True).create(vals)
+            )
         else:
             user.write(vals)
 


### PR DESCRIPTION
These users are not meant to be able to log in the normal way, it is always a redirection from another Odoo with automatic login

@fmr @sebastienbeau 