### PR TITLE
[17.0][FIX] auth_api_key: Use 401 for unauthorized user

### DIFF
--- a/auth_api_key/models/ir_http.py
+++ b/auth_api_key/models/ir_http.py
@@ -5,8 +5,9 @@
 
 import logging
 
+from werkzeug.exceptions import Unauthorized
+
 from odoo import models
-from odoo.exceptions import AccessDenied
 from odoo.http import request
 
 _logger = logging.getLogger(__name__)
@@ -33,4 +34,4 @@ class IrHttp(models.AbstractModel):
                 request.auth_api_key_id = auth_api_key.id
                 return True
         _logger.error("Wrong HTTP_API_KEY, access denied")
-        raise AccessDenied()
+        raise Unauthorized()


### PR DESCRIPTION
Port forward fix from 16.0 [#738](https://github.com/OCA/server-auth/pull/738)

As per documentation, using [401](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) as status code seems valid for a user who is not able to be authorized. However, [403](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403) is used for scenario where user is forbidden to access a resource. So, returning 401 instead of 403.