### PR TITLE
[17.0][IMP] auth_signup_verify_email: use get_auth_signup_qcontext instead of request.params

### DIFF
--- a/auth_signup_verify_email/controllers/main.py
+++ b/auth_signup_verify_email/controllers/main.py
@@ -21,12 +21,11 @@ class SignupVerifyEmail(AuthSignupHome):
         return super().web_auth_signup(*args, **kw)
 
     def passwordless_signup(self):
-        values = request.params
         qcontext = self.get_auth_signup_qcontext()
 
         # Check good format of e-mail
         try:
-            validate_email(values.get("login", ""))
+            validate_email(qcontext.get("login", ""))
         except EmailSyntaxError as error:
             qcontext["error"] = getattr(
                 error,
@@ -40,12 +39,10 @@ class SignupVerifyEmail(AuthSignupHome):
         except Exception as error:
             qcontext["error"] = str(error)
             return request.render("auth_signup.signup", qcontext)
-        if not values.get("email"):
-            values["email"] = values.get("login")
+        if not qcontext.get("email"):
+            qcontext["email"] = qcontext.get("login")
 
-        # remove values that could raise "Invalid field '*' on model 'res.users'"
-        values.pop("redirect", "")
-        values.pop("token", "")
+        values = self._prepare_signup_values(qcontext)
 
         # Remove password
         values["password"] = ""
@@ -61,7 +58,7 @@ class SignupVerifyEmail(AuthSignupHome):
             if (
                 request.env["res.users"]
                 .sudo()
-                .search([("login", "=", qcontext.get("login"))])
+                .search([("login", "=", values.get("login"))])
             ):
                 qcontext["error"] = _(
                     "Another user is already registered using this email" " address."

--- a/auth_signup_verify_email/tests/test_verify_email.py
+++ b/auth_signup_verify_email/tests/test_verify_email.py
@@ -1,12 +1,9 @@
 # Copyright 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from lxml.html import document_fromstring
+from unittest.mock import patch
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from unittest.mock import patch
+from lxml.html import document_fromstring
 
 from odoo.tests.common import HttpCase
 from odoo.tools.misc import mute_logger

--- a/auth_signup_verify_email/tests/test_verify_email.py
+++ b/auth_signup_verify_email/tests/test_verify_email.py
@@ -9,6 +9,7 @@ from odoo.tests.common import HttpCase
 from odoo.tools.misc import mute_logger
 
 from odoo.addons.mail.models import mail_template
+from odoo.addons.mail.tests.common import mail_new_test_user
 
 
 class UICase(HttpCase):
@@ -48,3 +49,13 @@ class UICase(HttpCase):
         self.data["login"] = "contributors@odoo-community.org"
         doc = self.html_doc(data=self.data)
         self.assertTrue(doc.xpath('//p[@class="alert alert-success"]'))
+
+    def test_already_exists(self):
+        already_existing_user = mail_new_test_user(
+            self.env,
+            login="king@example.com",
+            name="The King",
+        )
+        self.data["login"] = already_existing_user.login
+        doc = self.html_doc(data=self.data)
+        self.assertTrue(doc.xpath('//p[@class="alert alert-danger"]'))


### PR DESCRIPTION
This allows more flexible customizations