### PR TITLE
[17.0][FIX] users_ldap_populate: Decode login information

### DIFF
--- a/users_ldap_populate/models/users_ldap.py
+++ b/users_ldap_populate/models/users_ldap.py
@@ -66,6 +66,8 @@ class CompanyLDAP(models.Model):
             results = self._get_ldap_entry_dicts(conf)
             for result in results:
                 login = result[1][login_attr][0].lower().strip()
+                if isinstance(login, bytes):
+                    login = login.decode()
                 user_id = None
                 try:
                     user_id = self.with_context(


### PR DESCRIPTION
Forward-port of #817 

When iterating through the users from LDAP, if the login information is read in bytes, passing the value in bytes to the psycopg2 library doesn't work, failing with this error:

```
psycopg2.errors.UndefinedFunction: operator does not exist: text = bytea
LINE 1: SELECT id FROM res_users WHERE lower(login)='...
```

so we need to decode the result before to get a pure string.

@Tecnativa TT56992