### PR TITLE
[16][cross_connect_server] Make external user as inactive to avoid pollution in users and tables across Odoo

### DIFF
--- a/cross_connect_server/models/cross_connect_client.py
+++ b/cross_connect_server/models/cross_connect_client.py
@@ -69,7 +69,7 @@ class CrossConnectClient(models.Model):
         if groups - self.group_ids or not groups.exists():
             raise AccessDenied(_("You are not allowed to access this endpoint."))
 
-        user = self.user_ids.filtered(
+        user = self.with_context(active_test=False).user_ids.filtered(
             lambda u: u.cross_connect_client_user_id == access_request.id
         )
         vals = {
@@ -80,6 +80,7 @@ class CrossConnectClient(models.Model):
             "groups_id": [(6, 0, groups.ids)],
             "cross_connect_client_id": self.id,
             "cross_connect_client_user_id": access_request.id,
+            "active": False,
         }
         # Create user if not exists
         if not user:

--- a/cross_connect_server/tests/test_cross_connect_server.py
+++ b/cross_connect_server/tests/test_cross_connect_server.py
@@ -145,7 +145,9 @@ class TestCrossConnectServer(FastAPITransactionCase):
             self.assertEqual(response.status_code, 401)
 
     def test_access_ok(self):
-        with RecordCapturer(self.env["res.users"], []) as rc:
+        with RecordCapturer(
+            self.env["res.users"].with_context(active_test=False), []
+        ) as rc:
             with self._create_test_client() as test_client:
                 response = test_client.post(
                     "/cross_connect/access",
@@ -227,7 +229,9 @@ class TestCrossConnectServer(FastAPITransactionCase):
         self.assertEqual(len(rc.records), 0)
 
     def test_access_existing(self):
-        with RecordCapturer(self.env["res.users"], []) as rc:
+        with RecordCapturer(
+            self.env["res.users"].with_context(active_test=False), []
+        ) as rc:
             with self._create_test_client() as test_client:
                 response = test_client.post(
                     "/cross_connect/access",
@@ -282,7 +286,9 @@ class TestCrossConnectServer(FastAPITransactionCase):
         )
 
     def test_login_ok(self):
-        with RecordCapturer(self.env["res.users"], []) as rc:
+        with RecordCapturer(
+            self.env["res.users"].with_context(active_test=False), []
+        ) as rc:
             with self._create_test_client() as test_client:
                 response = test_client.post(
                     "/cross_connect/access",


### PR DESCRIPTION
@sebastienbeau @paradoxxxzero 
Do you see any reason to have this kind of users active ?

It is an issue, because, with users from multiple instance we could (we will) have users with the same name.
It then pollutes the partner and user database.