### PR TITLE
[16][IMP] auth_oidc: add `end_session_endpoint`

### DIFF
--- a/auth_oidc/models/auth_oauth_provider.py
+++ b/auth_oidc/models/auth_oauth_provider.py
@@ -49,6 +49,7 @@ class AuthOauthProvider(models.Model):
     auth_link_params = fields.Char(
         help="Additional parameters for the auth link. For example: {'prompt':'select_account'}"
     )
+    end_session_endpoint = fields.Char(string="End Session URL")
 
     @tools.ormcache("self.jwks_uri", "kid")
     def _get_keys(self, kid):

--- a/auth_oidc/views/auth_oauth_provider.xml
+++ b/auth_oidc/views/auth_oauth_provider.xml
@@ -18,6 +18,7 @@
             <field name="validation_endpoint" position="after">
                 <field name="token_endpoint" />
                 <field name="jwks_uri" />
+                <field name="end_session_endpoint" />
             </field>
             <field name="auth_endpoint" position="after">
                 <field name="auth_link_params" />


### PR DESCRIPTION
Improved `auth_oidc` module with the logout mechanism implemented in version 14.0 in commit 9b6f5eed7932bfcabfe5ac4887119f8f94a10939 and adapt to the 16.0 logout flow.

Co-authored-by: @konykon