### PR TITLE
[18.0][IMP] impersonate_login: Optimize database performance for partner deletion

### DIFF
--- a/impersonate_login/models/mail_message.py
+++ b/impersonate_login/models/mail_message.py
@@ -14,6 +14,7 @@ class Message(models.Model):
         comodel_name="res.partner",
         compute="_compute_impersonated_author_id",
         store=True,
+        index=True,
     )
 
     body = fields.Html(


### PR DESCRIPTION
In our production environment, the mail_message table contains approximately 8.52 million rows, and the res_partner table has about 48,000 rows.

Deleting a single partner took roughly 70 seconds. After adding the database index, the operation was optimized to complete in approximately 3 seconds.