### PR TITLE
[18.0][FIX] auth_saml: do not crash if no users

### DIFF
--- a/auth_saml/models/res_users.py
+++ b/auth_saml/models/res_users.py
@@ -183,13 +183,14 @@ class ResUser(models.Model):
         """Set the password to a value that prohibits logging."""
         # Use SQL to blank the password to avoid sending security messages (done in
         # mail module) to end users.
-        _logger.debug("Removing password from %s user(s)", len(self.ids))
-        # similar to what Odoo does in Users._set_encrypted_password
-        self.env.cr.execute(
-            "UPDATE res_users SET password = NULL WHERE id IN %s",
-            (tuple(self.ids),),
-        )
-        self.invalidate_recordset(fnames=["password"])
+        if self:  # no users, nothing to do.
+            _logger.debug("Removing password from %s user(s)", len(self.ids))
+            # similar to what Odoo does in Users._set_encrypted_password
+            self.env.cr.execute(
+                "UPDATE res_users SET password = NULL WHERE id IN %s",
+                (tuple(self.ids),),
+            )
+            self.invalidate_recordset(fnames=["password"])
 
     def allow_saml_and_password_changed(self):
         """Called after the parameter is changed."""

--- a/auth_saml/tests/__init__.py
+++ b/auth_saml/tests/__init__.py
@@ -1,1 +1,4 @@
-from . import fake_idp, test_pysaml, test_models_saml_attribute_mapping
+from . import fake_idp
+from . import test_pysaml
+from . import test_models_saml_attribute_mapping
+from . import test_param_change

--- a/auth_saml/tests/test_param_change.py
+++ b/auth_saml/tests/test_param_change.py
@@ -1,0 +1,10 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestParamChange(TransactionCase):
+    def test_set_param(self):
+        """Changing the parameter should go through without error"""
+        self.env["ir.config_parameter"].set_param(
+            "auth_saml.allow_saml_uid_and_internal_password",
+            False,
+        )


### PR DESCRIPTION
If self is empty, the syntax is invalid and will crash. Since there is no `ensure_one`, this case should normally not cause any problems.