### PR TITLE
[16.0][FW] impersonate_login: Restrict the ability to impersonate users with administrative access to the settings

### DIFF
--- a/impersonate_login/README.rst
+++ b/impersonate_login/README.rst
@@ -40,7 +40,10 @@ following measures are in place:
 -  Mails and messages are sent from the original user.
 -  Impersonated logins are logged and can be consulted through the
    Settings -> Technical menu.
--  
+-  To prevent users with "Administration: Settings" rights from being
+   impersonated, enable the restrict_impersonate_admin_settings field in
+   the settings. This will restrict the ability to impersonate users
+   with administrative access to the settings.
 
 There is an alternative module to allow logins as another user
 (auth_admin_passkey), but it does not support these security mechanisms.
@@ -54,6 +57,10 @@ Configuration
 =============
 
 The impersonating user must belong to group "Impersonate Users".
+
+If you want to forbid impersonation of users with the "Administration:
+Settings" access rights, enable the *Restrict Impersonation of
+"Administration: Settings" Users* option in the settings.
 
 Usage
 =====

--- a/impersonate_login/__manifest__.py
+++ b/impersonate_login/__manifest__.py
@@ -20,6 +20,7 @@
     "data": [
         "security/group.xml",
         "security/ir.model.access.csv",
+        "views/res_config_settings.xml",
         "views/res_users.xml",
         "views/impersonate_log.xml",
     ],

--- a/impersonate_login/models/__init__.py
+++ b/impersonate_login/models/__init__.py
@@ -4,3 +4,4 @@ from . import mail_thread
 from . import mail_message
 from . import impersonate_log
 from . import model
+from . import res_config_settings

--- a/impersonate_login/models/res_config_settings.py
+++ b/impersonate_login/models/res_config_settings.py
@@ -1,0 +1,15 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    restrict_impersonate_admin_settings = fields.Boolean(
+        string="Restrict Impersonation of 'Administration: Settings' Users",
+        config_parameter="impersonate_login.restrict_impersonate_admin_settings",
+        help=(
+            "If enabled, users with the 'Administration: Settings' access right"
+            " cannot be impersonated."
+        ),
+        default=False,
+    )

--- a/impersonate_login/models/res_users.py
+++ b/impersonate_login/models/res_users.py
@@ -24,6 +24,20 @@ class Users(models.Model):
 
     def impersonate_login(self):
         if request:
+            config_restrict = (
+                self.env["ir.config_parameter"]
+                .sudo()
+                .get_param("impersonate_login.restrict_impersonate_admin_settings")
+            )
+            if config_restrict:
+                admin_settings_group = self.env.ref("base.group_system")
+                if admin_settings_group in self.groups_id:
+                    raise UserError(
+                        _(
+                            "You cannot impersonate users with"
+                            " 'Administration: Settings' access rights."
+                        )
+                    )
             if request.session.impersonate_from_uid:
                 if self.id == request.session.impersonate_from_uid:
                     return self.back_to_origin_login()

--- a/impersonate_login/readme/CONFIGURE.md
+++ b/impersonate_login/readme/CONFIGURE.md
@@ -1,1 +1,5 @@
 The impersonating user must belong to group "Impersonate Users".
+
+If you want to prevent impersonation of users with the *Administration: Settings*
+rights, enable the *Restrict Impersonation of "Administration: Settings" Users*
+option in the settings.

--- a/impersonate_login/readme/DESCRIPTION.md
+++ b/impersonate_login/readme/DESCRIPTION.md
@@ -6,6 +6,7 @@ To ensure that any abuse of this feature will not go unnoticed, the following me
 * In the chatter, it is displayed who is the user that is logged as another user.
 * Mails and messages are sent from the original user.
 * Impersonated logins are logged and can be consulted through the Settings -> Technical menu.
-* 
+* You can optionally forbid impersonation of users with "Administration: Settings"
+  rights by enabling the related option in the settings.
 There is an alternative module to allow logins as another user (auth_admin_passkey),
 but it does not support these security mechanisms.

--- a/impersonate_login/static/description/index.html
+++ b/impersonate_login/static/description/index.html
@@ -381,7 +381,10 @@ another user.</li>
 <li>Mails and messages are sent from the original user.</li>
 <li>Impersonated logins are logged and can be consulted through the
 Settings -&gt; Technical menu.</li>
-<li></li>
+<li>To prevent users with “Administration: Settings” rights from being
+impersonated, enable the <cite>restrict_impersonate_admin_settings</cite> field in
+the settings. This will restrict the ability to impersonate users
+with administrative access to the settings.</li>
 </ul>
 <p>There is an alternative module to allow logins as another user
 (auth_admin_passkey), but it does not support these security mechanisms.</p>
@@ -402,6 +405,9 @@ Settings -&gt; Technical menu.</li>
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
 <p>The impersonating user must belong to group “Impersonate Users”.</p>
+<p>If you want to forbid impersonation of users with the “Administration:
+Settings” access rights, enable the <em>Restrict Impersonation of “Administration:
+Settings” Users</em> option in the settings.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>

--- a/impersonate_login/tests/test_impersonate_login.py
+++ b/impersonate_login/tests/test_impersonate_login.py
@@ -258,3 +258,37 @@ class TestImpersonateLogin(HttpCase):
         self.assertEqual(result, True)
         self.assertEqual(contact.ref, "abc")
         self.assertEqual(contact.write_uid, self.admin_user)
+
+    def test_05_limit_access_to_admin(self):
+        """
+        Test restriction on impersonating admin users
+        with 'Administration: Settings' access rights.
+        """
+        config_settings = self.env["res.config.settings"].create(
+            {"restrict_impersonate_admin_settings": True}
+        )
+        config_settings.execute()
+
+        config_restrict = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("impersonate_login.restrict_impersonate_admin_settings")
+        )
+        self.assertTrue(config_restrict)
+
+        admin_settings_group = self.env.ref("base.group_system")
+        self.admin_user.groups_id += admin_settings_group
+
+        self.authenticate(user="demo", password="demo")
+        self.assertEqual(self.session.uid, self.demo_user.id)
+
+        self.demo_user.groups_id += self.env.ref(
+            "impersonate_login.group_impersonate_login"
+        )
+
+        with mute_logger("odoo.http"):
+            data = self._impersonate_user(self.admin_user)
+        self.assertEqual(
+            data["error"]["data"]["message"],
+            "You cannot impersonate users with 'Administration: Settings' access rights.",
+        )

--- a/impersonate_login/views/res_config_settings.xml
+++ b/impersonate_login/views/res_config_settings.xml
@@ -1,0 +1,36 @@
+<odoo>
+    <record id="view_res_config_settings_impersonate" model="ir.ui.view">
+        <field name="name">res.config.settings.impersonate</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="base_setup.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='user_default_rights']" position="after">
+                <div id="impersonate_login">
+                    <h2>Impersonation Login</h2>
+                    <div
+                        class="row mt16 o_settings_container"
+                        name="impersonate_login_settings_container"
+                    >
+                        <div
+                            class="col-12 col-lg-6 o_setting_box"
+                            id="impersonate_login_settings"
+                        >
+                            <div class="o_setting_left_pane">
+                                <field name="restrict_impersonate_admin_settings" />
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="restrict_impersonate_admin_settings">
+                                    Restrict Impersonation of 'Administration: Settings' Users
+                                </label>
+                                <div class="text-muted">
+                                    Prevents impersonating users that have the
+                                    "Administration: Settings" access rights.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Fowardport of #730 