### PR TITLE
[17.0][FIX] auth_saml: fix sending password change mail when blanking password

### DIFF
--- a/auth_saml/models/res_users_saml.py
+++ b/auth_saml/models/res_users_saml.py
@@ -32,5 +32,6 @@ class ResUserSaml(models.Model):
         # Redefined to remove password if necessary
         result = super().create(vals_list)
         if not self.env["res.users"].allow_saml_and_password():
-            result.mapped("user_id").write({"password": False})
+            # Avoid sending a security mail by using this method instead of a write
+            result.mapped("user_id")._set_password_blank()
         return result

--- a/auth_saml/readme/newsfragments/+no-password-mail.bugfix.rst
+++ b/auth_saml/readme/newsfragments/+no-password-mail.bugfix.rst
@@ -1,0 +1,1 @@
+Fix sending a mail when configuring SAML for a user.


### PR DESCRIPTION
This needs to be ported in 18.0 and included in 19.0 (in #871)