### PR TITLE
[17.0][FIX] auth_signup_verify_email: ignore captcha fields in passwordless signup

### DIFF
--- a/auth_signup_verify_email/controllers/main.py
+++ b/auth_signup_verify_email/controllers/main.py
@@ -6,6 +6,7 @@ import logging
 from email_validator import EmailSyntaxError, EmailUndeliverableError, validate_email
 
 from odoo import _
+from odoo.exceptions import UserError, ValidationError
 from odoo.http import request, route
 
 from odoo.addons.auth_signup.controllers.main import AuthSignupHome
@@ -21,8 +22,22 @@ class SignupVerifyEmail(AuthSignupHome):
         return super().web_auth_signup(*args, **kw)
 
     def passwordless_signup(self):
-        values = request.params
+        values = dict(request.params)
         qcontext = self.get_auth_signup_qcontext()
+
+        verify_captcha = getattr(
+            request.env["ir.http"], "_verify_request_recaptcha_token", None
+        )
+        if verify_captcha:
+            try:
+                if not verify_captcha("signup"):
+                    qcontext["error"] = _(
+                        "Suspicious activity detected by human verification."
+                    )
+                    return request.render("auth_signup.signup", qcontext)
+            except (UserError, ValidationError) as error:
+                qcontext["error"] = str(error)
+                return request.render("auth_signup.signup", qcontext)
 
         # Check good format of e-mail
         try:
@@ -44,8 +59,16 @@ class SignupVerifyEmail(AuthSignupHome):
             values["email"] = values.get("login")
 
         # remove values that could raise "Invalid field '*' on model 'res.users'"
-        values.pop("redirect", "")
-        values.pop("token", "")
+        for key in (
+            "redirect",
+            "token",
+            "csrf_token",
+            "confirm_password",
+            "turnstile_captcha",
+            "recaptcha_token_response",
+            "g-recaptcha-response",
+        ):
+            values.pop(key, "")
 
         # Remove password
         values["password"] = ""

--- a/auth_signup_verify_email/tests/test_verify_email.py
+++ b/auth_signup_verify_email/tests/test_verify_email.py
@@ -8,6 +8,7 @@ try:
 except ImportError:
     from unittest.mock import patch
 
+from odoo.exceptions import UserError
 from odoo.tests.common import HttpCase
 from odoo.tools.misc import mute_logger
 
@@ -51,3 +52,38 @@ class UICase(HttpCase):
         self.data["login"] = "contributors@odoo-community.org"
         doc = self.html_doc(data=self.data)
         self.assertTrue(doc.xpath('//p[@class="alert alert-success"]'))
+
+    @mute_logger("odoo.addons.auth_signup_verify_email.controllers.main")
+    def test_good_email_with_captcha_fields(self):
+        """Test acceptance when captcha fields are present in POST data."""
+        self.data["login"] = "contributors@odoo-community.org"
+        self.data["turnstile_captcha"] = "dummy-turnstile-token"
+        self.data["recaptcha_token_response"] = "dummy-recaptcha-token"
+        doc = self.html_doc(data=self.data)
+        self.assertTrue(doc.xpath('//p[@class="alert alert-success"]'))
+
+    @mute_logger("odoo.addons.auth_signup_verify_email.controllers.main")
+    def test_captcha_verification_error(self):
+        """Test rejection when captcha verification raises an error."""
+        self.data["login"] = "contributors@odoo-community.org"
+        with patch.object(
+            type(self.env["ir.http"]),
+            "_verify_request_recaptcha_token",
+            side_effect=UserError("Captcha failed"),
+            create=True,
+        ):
+            doc = self.html_doc(data=self.data)
+        self.assertTrue(doc.xpath('//p[@class="alert alert-danger"]'))
+
+    @mute_logger("odoo.addons.auth_signup_verify_email.controllers.main")
+    def test_captcha_verification_false(self):
+        """Test rejection when captcha verification returns False."""
+        self.data["login"] = "contributors@odoo-community.org"
+        with patch.object(
+            type(self.env["ir.http"]),
+            "_verify_request_recaptcha_token",
+            return_value=False,
+            create=True,
+        ):
+            doc = self.html_doc(data=self.data)
+        self.assertTrue(doc.xpath('//p[@class="alert alert-danger"]'))


### PR DESCRIPTION
### Problem

When passwordless signup is used, the controller forwards raw request parameters to res.users.signup().
If captcha modules are enabled (Cloudflare Turnstile / reCAPTCHA), extra POST fields such as
turnstile_captcha and recaptcha_token_response are present and get passed to user creation.

This causes signup to crash with:
SignupError: Invalid field 'turnstile_captcha' on model 'res.users'

### Root cause

passwordless_signup() was using request.params directly and only removed redirect and token,
leaving captcha/transient fields in values.

### Fix

- Use a mutable copy of request params (dict(request.params)).
- Remove transient/non-user fields before calling signup, including:
  - turnstile_captcha
  - recaptcha_token_response
  - g-recaptcha-response
  - csrf_token
  - confirm_password
  - redirect
  - token
- Keep captcha verification in flow, but call it only when _verify_request_recaptcha_token
  exists on ir.http (to avoid hard dependency regressions when captcha addon is not installed).

### Tests

Added a regression test that posts captcha fields together with a valid signup email and
verifies the passwordless signup still succeeds.

### Impact

- Fixes signup crash in installations using captcha on /web/signup.
- Backward-compatible for deployments without captcha modules.
