### PR TITLE
[18.0][FIX] vault: Error when user clicks on reencrypt

### DIFF
--- a/vault/static/src/backend/controller.esm.js
+++ b/vault/static/src/backend/controller.esm.js
@@ -159,7 +159,7 @@ patch(FormController.prototype, {
             );
 
             for (const rec of records) {
-                const val = await this.vault_utils.sym_decrypt(
+                const val = await self.vault_utils.sym_decrypt(
                     current_key,
                     rec.value,
                     rec.iv
@@ -176,8 +176,8 @@ patch(FormController.prototype, {
                     continue;
                 }
 
-                const iv = this.vault_utils.generate_iv_base64();
-                const encrypted = await this.vault_utils.sym_encrypt(
+                const iv = self.vault_utils.generate_iv_base64();
+                const encrypted = await self.vault_utils.sym_encrypt(
                     master_key,
                     val,
                     iv


### PR DESCRIPTION
Before this changes when a user clicks on reencrypt button of a vault, an error is thrown.

With this changes, the problem does not occur anymore, and it works normally.

cc @Tecnativa TT61203

ping @victoralmau @pedrobaeza 