### PR TITLE
fix: avoid unnecessary DB query on mail.message creation by setting b…

### DIFF
--- a/impersonate_login/models/mail_message.py
+++ b/impersonate_login/models/mail_message.py
@@ -20,7 +20,7 @@ class Message(models.Model):
     body = fields.Html(
         compute="_compute_message_body",
         inverse="_inverse_message_body",
-        store=True,
+        store=False,
         readonly=False,
     )
 


### PR DESCRIPTION
…ody store=False

store=True on a computed body field causes an extra SELECT after every mail.message INSERT, breaking documents performance test and adding unnecessary DB load in production, In my case this happend whrn i added account_reports in my depends and ran unit test with module impersonate_login with my custom module