### PR TITLE
[19.0][FIX] impersonate_login: preserve attachment creator ownership

### DIFF
--- a/impersonate_login/models/model.py
+++ b/impersonate_login/models/model.py
@@ -11,6 +11,13 @@ class BaseModel(models.AbstractModel):
 
     def _prepare_create_values(self, vals_list):
         result_vals_list = super()._prepare_create_values(vals_list)
+        # Keep core attachment access semantics intact.
+        # For temporary/generated attachments (often without res_model/res_id),
+        # read access falls back to creator ownership. Rewriting create_uid to
+        # the original impersonator can make the active impersonated user lose
+        # access immediately in the same flow (e.g. compose email after report).
+        if self._name == "ir.attachment":
+            return result_vals_list
         if (
             request
             and request.session.get("impersonate_from_uid")
@@ -23,6 +30,8 @@ class BaseModel(models.AbstractModel):
     def write(self, vals):
         """Overwrite the write_uid with the impersonating user"""
         res = super().write(vals)
+        if self._name == "ir.attachment":
+            return res
         if (
             request
             and request.session.get("impersonate_from_uid")


### PR DESCRIPTION
## Summary
- Avoid rewriting `create_uid` / `write_uid` on `ir.attachment` during impersonation in `impersonate_login`.
- This keeps Odoo core attachment access semantics for temporary/generated attachments (not yet linked to a record via `res_model`/`res_id`).
- Fixes access errors during PO confirm/email compose where generated report attachments were created under the original impersonator and immediately unreadable by the active impersonated user.

## Options considered
- **Option A (implemented):** Exclude `ir.attachment` from impersonate `create_uid`/`write_uid` rewriting in `base` overrides.
  - Pros: very small patch, aligns with core `ir.attachment` ownership checks, no security rule override.
  - Cons: attachment audit attribution stays with effective user instead of impersonator for these records.
- **Option B (tried, reverted):** Narrow `ir.attachment._check_access` override to whitelist only orphan attachments created by `impersonate_from_uid` in impersonated sessions.
  - This initially caused a recursion error because filtering forbidden attachment records triggered attachment access checks again.
  - Even after a recursion-safe adjustment, behavior remained brittle and more invasive in a security-critical path.
- **Option C (rejected):** Broadly bypass core attachment check branch around owner mismatch.
  - Rejected as too risky from a security perspective.

## Failures observed during investigation
- Access error on read for generated attachment in mail compose flow:
  - `Sorry, you are not allowed to access this document ... Records: ir.attachment(...), User: <impersonated uid>`
- Recursion failure with `_check_access` override approach:
  - `RecursionError: maximum recursion depth exceeded`
