### PR TITLE
auth_oidc: models: res_users: Send cleint secret as well

### DIFF
--- a/auth_oidc/models/auth_oauth_provider.py
+++ b/auth_oidc/models/auth_oauth_provider.py
@@ -38,6 +38,9 @@ class AuthOauthProvider(models.Model):
     client_secret = fields.Char(
         help="Used in OpenID Connect authorization code flow for confidential clients.",
     )
+    client_secret_post = fields.Boolean(
+        help="Use Client Secret in authorization post requests"
+    )
     code_verifier = fields.Char(
         default=lambda self: secrets.token_urlsafe(32), help="Used for PKCE."
     )

--- a/auth_oidc/models/res_users.py
+++ b/auth_oidc/models/res_users.py
@@ -27,16 +27,21 @@ class ResUsers(models.Model):
         auth = None
         if oauth_provider.client_secret:
             auth = (oauth_provider.client_id, oauth_provider.client_secret)
+
+        post_data = dict(
+            client_id=oauth_provider.client_id,
+            grant_type="authorization_code",
+            code=code,
+            code_verifier=oauth_provider.code_verifier,  # PKCE
+            redirect_uri=request.httprequest.url_root + "auth_oauth/signin",
+        )
+
+        if oauth_provider.client_secret_post:
+            post_data["client_secret"] = oauth_provider.client_secret
+
         response = requests.post(
             oauth_provider.token_endpoint,
-            data=dict(
-                client_id=oauth_provider.client_id,
-                client_secret=oauth_provider.client_secret,
-                grant_type="authorization_code",
-                code=code,
-                code_verifier=oauth_provider.code_verifier,  # PKCE
-                redirect_uri=request.httprequest.url_root + "auth_oauth/signin",
-            ),
+            data=post_data,
             auth=auth,
             timeout=10,
         )

--- a/auth_oidc/models/res_users.py
+++ b/auth_oidc/models/res_users.py
@@ -31,6 +31,7 @@ class ResUsers(models.Model):
             oauth_provider.token_endpoint,
             data=dict(
                 client_id=oauth_provider.client_id,
+                client_secret=oauth_provider.client_secret,
                 grant_type="authorization_code",
                 code=code,
                 code_verifier=oauth_provider.code_verifier,  # PKCE

--- a/auth_oidc/views/auth_oauth_provider.xml
+++ b/auth_oidc/views/auth_oauth_provider.xml
@@ -14,6 +14,7 @@
             </field>
             <field name="client_id" position="after">
                 <field name="client_secret" />
+                <field name="client_secret_post" />
             </field>
             <field name="validation_endpoint" position="after">
                 <field name="token_endpoint" />


### PR DESCRIPTION
Otherwise most OIDC providers will fail the token endpoint call

This is a bug fix btw