### PR TITLE
[IMP][FIX] auth_oauth_multi_token: re-fetch user after signup to avoid None

### DIFF
--- a/auth_oauth_multi_token/models/res_users.py
+++ b/auth_oauth_multi_token/models/res_users.py
@@ -57,6 +57,10 @@ class ResUsers(models.Model):
         # this by the existing oauth_access_token which acts as oauth_master_uuid
         params["access_token"] = user.oauth_access_token
         res = super()._auth_oauth_signin(provider, validation, params)
+        # re-fetch AFTER signup
+        user = self.search(
+            [("oauth_uid", "=", oauth_uid), ("oauth_provider_id", "=", provider)]
+        )
 
         if not user:
             raise exceptions.AccessDenied()


### PR DESCRIPTION
When signing in with OAuth2 multi-token, the user record may not exist before calling super()._auth_oauth_signin(). Re-fetching the user after signup ensures that the multi-token creation uses the correct user record.

This fixes AccessDenied errors on first-time OAuth login.