### PR TITLE
[18.0][IMP] auth_oidc_environment: extra fields

### DIFF
--- a/auth_oidc_environment/__manifest__.py
+++ b/auth_oidc_environment/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Auth Oidc Environment",
     "summary": """
         This module allows to use server env for OIDC configuration""",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "license": "AGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/server-auth",

--- a/auth_oidc_environment/migrations/18.0.1.1.0/post-migration.py
+++ b/auth_oidc_environment/migrations/18.0.1.1.0/post-migration.py
@@ -1,0 +1,11 @@
+# Copyright 2026 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env["auth.oauth.provider"]._preserve_not_env_managed_data(
+        ["auth_endpoint", "token_endpoint", "jwks_uri"]
+    )

--- a/auth_oidc_environment/models/auth_oauth_provider.py
+++ b/auth_oidc_environment/models/auth_oauth_provider.py
@@ -14,6 +14,9 @@ class AuthOauthProvider(models.Model):
         auth_fields = {
             "client_id": {},
             "client_secret": {},
+            "auth_endpoint": {},
+            "token_endpoint": {},
+            "jwks_uri": {},
         }
         auth_fields.update(base_fields)
         return auth_fields

--- a/auth_oidc_environment/tests/test_auth_oidc_environment.py
+++ b/auth_oidc_environment/tests/test_auth_oidc_environment.py
@@ -13,7 +13,12 @@ from odoo.addons.server_environment.tests.common import ServerEnvironmentCase
 class TestEnvironmentVariables(ServerEnvironmentCase):
     def test_env_variables(self):
         env_var = (
-            "[auth_oauth_provider.sample]\n" "client_id=foo\n" "client_secret=bar\n"
+            "[auth_oauth_provider.sample]\n"
+            "client_id=foo\n"
+            "client_secret=bar\n"
+            "auth_endpoint=https://test/auth/endpoint\n"
+            "token_endpoint=https://test/token/endpoint\n"
+            "jwks_uri=https://test/jwks/uri\n"
         )
         with self.set_config_dir(None), self.set_env_variables(env_var):
             parser = server_env._load_config()
@@ -25,5 +30,8 @@ class TestEnvironmentVariables(ServerEnvironmentCase):
                 {
                     "client_id": "foo",
                     "client_secret": "bar",
+                    "auth_endpoint": "https://test/auth/endpoint",
+                    "token_endpoint": "https://test/token/endpoint",
+                    "jwks_uri": "https://test/jwks/uri",
                 },
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.whool]
+depends_override = { "server_environment" = "odoo-addon-server_environment ==18.0.*, >18.0.1.0.6" }


### PR DESCRIPTION
Needs https://github.com/OCA/server-env/pull/264

I believe more fields make sense to be configurable by environment.

Typically when you use different SSO for test and production.