### PR TITLE
change to base.group_system for view permissions

### DIFF
--- a/auth_oauth_multi_token/views/res_users.xml
+++ b/auth_oauth_multi_token/views/res_users.xml
@@ -10,7 +10,7 @@
                 <separator string="OAuth Tokens" colspan="4" />
                 <div
                     name="oauth_access_max_token"
-                    invisible="id != uid"
+                    groups="base.group_system"
                     class="d-md-flex mt-3"
                 >
                     <div class="col-md-6 col-lg-3 d-flex flex-column">
@@ -25,7 +25,7 @@
                 </div>
                 <div
                     name="multi_token_info"
-                    invisible="id != uid"
+                    groups="base.group_system"
                     class="d-md-flex mt-3"
                 >
                     <div class="col-md-6 col-lg-3 d-flex flex-column" />


### PR DESCRIPTION
Seems like a logical change to make the OAUTH Tokens information visible to administrative users in the base.group.system as opposed to invisible="id != uid".

Right now a full system admin cannot set or set the token limit or clear them. This change allows system admins to manage tokens limits and tokens for users. 