### PR TITLE
[FIX] auth_signup_verify_email: ensure compatibility with reCaptcha

### DIFF
--- a/auth_signup_verify_email/controllers/main.py
+++ b/auth_signup_verify_email/controllers/main.py
@@ -6,6 +6,7 @@ import logging
 from email_validator import EmailSyntaxError, EmailUndeliverableError, validate_email
 
 from odoo import _
+from odoo.exceptions import UserError
 from odoo.http import request, route
 
 from odoo.addons.auth_signup.controllers.main import AuthSignupHome
@@ -26,6 +27,8 @@ class SignupVerifyEmail(AuthSignupHome):
 
         # Check good format of e-mail
         try:
+            if not request.env["ir.http"]._verify_request_recaptcha_token("signup"):
+                raise UserError(_("Suspicious activity detected by Google reCaptcha."))
             validate_email(values.get("login", ""))
         except EmailSyntaxError as error:
             qcontext["error"] = getattr(

--- a/auth_signup_verify_email/tests/test_verify_email.py
+++ b/auth_signup_verify_email/tests/test_verify_email.py
@@ -11,6 +11,7 @@ except ImportError:
 from odoo.tests.common import HttpCase
 from odoo.tools.misc import mute_logger
 
+from odoo.addons.base.models import ir_http
 from odoo.addons.mail.models import mail_template
 
 
@@ -44,6 +45,15 @@ class UICase(HttpCase):
         self.data["login"] = "bad email"
         doc = self.html_doc(data=self.data)
         self.assertTrue(doc.xpath('//p[@class="alert alert-danger"]'))
+
+    def test_failed_recaptcha(self):
+        """Test rejection of failed reCaptcha."""
+        with patch.object(
+            ir_http.IrHttp, "_verify_request_recaptcha_token", return_value=False
+        ):
+            self.data["login"] = "contributors@odoo-community.org"
+            doc = self.html_doc(data=self.data)
+            self.assertTrue(doc.xpath('//p[@class="alert alert-danger"]'))
 
     @mute_logger("odoo.addons.auth_signup_verify_email.controllers.main")
     def test_good_email(self):


### PR DESCRIPTION
restore the call to the recaptcha on signup.

The method to be called exist in base and should be called
<img width="712" height="107" alt="image" src="https://github.com/user-attachments/assets/8db80f60-4f2f-447a-a0b2-d58e9595fd6c" />

Previous PR #783 
Original issue #774 