### PR TITLE
[FIX] password_security: accept extra kwargs in do_signup

### DIFF
--- a/password_security/__manifest__.py
+++ b/password_security/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Password Security",
     "summary": "Allow admin to set password security requirements.",
-    "version": "17.0.2.0.0",
+    "version": "17.0.2.0.1",
     "author": "LasLabs, "
     "Onestein, "
     "Kaushal Prajapati, "

--- a/password_security/controllers/main.py
+++ b/password_security/controllers/main.py
@@ -15,11 +15,11 @@ _logger = logging.getLogger(__name__)
 
 
 class PasswordSecurityHome(AuthSignupHome):
-    def do_signup(self, qcontext):
+    def do_signup(self, qcontext, **kw):
         password = qcontext.get("password")
         user = request.env.user
         user._check_password(password)
-        return super().do_signup(qcontext)
+        return super().do_signup(qcontext, **kw)
 
     @http.route()
     def web_login(self, *args, **kw):

--- a/password_security/tests/test_signup.py
+++ b/password_security/tests/test_signup.py
@@ -44,7 +44,7 @@ class TestPasswordSecuritySignup(HttpCase):
     def test_01_signup_user_fail(self):
         """It should fail when signup user with weak password"""
         # Weak password: signup failed
-        response = self.signup("jackoneill", "jackoneill")
+        response = self.signup("jackoneill@example.com", "jackoneill")
 
         # Ensure we stay in the signup page
         self.assertEqual(response.request.path_url, "/web/signup")
@@ -57,7 +57,7 @@ class TestPasswordSecuritySignup(HttpCase):
     def test_02_signup_user_success(self):
         """It should succeed when signup user with strong password"""
         # Weak password: signup failed
-        response = self.signup("jackoneill", "!asdQWE12345_3")
+        response = self.signup("jackoneill@example.com", "!asdQWE12345_3")
 
         # Ensure we were logged in
         self.assertEqual(


### PR DESCRIPTION
Closes #939

## Problem

Odoo 17's standard `auth_signup` controller calls `do_signup(qcontext, validate_email=...)`. The `password_security` override of `do_signup` does not accept this keyword argument, causing the following crash on password reset:

```
TypeError: PasswordSecurityHome.do_signup() got an unexpected keyword argument 'validate_email'
```

This is reproducible with `password_security` alone, no other OCA auth module needs to be installed.

## Fix

Update the `do_signup` override to accept and forward extra keyword arguments via `**kw`. This fixes the immediate issue and makes the override robust to future signature changes in Odoo standard.