### PR TITLE
[FIX] auth_api_key: Read API key from headers

### DIFF
--- a/auth_api_key/models/ir_http.py
+++ b/auth_api_key/models/ir_http.py
@@ -18,8 +18,8 @@ class IrHttp(models.AbstractModel):
 
     @classmethod
     def _auth_method_api_key(cls):
-        headers = request.httprequest.environ
-        api_key = headers.get("HTTP_API_KEY")
+        headers = request.httprequest.headers
+        api_key = headers.get("API_KEY")
         if api_key:
             request.update_env(user=1)
             auth_api_key = request.env["auth.api.key"]._retrieve_api_key(api_key)

--- a/auth_api_key/tests/test_auth_api_key.py
+++ b/auth_api_key/tests/test_auth_api_key.py
@@ -1,7 +1,12 @@
 # Copyright 2018 ACSONE SA/NV
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from werkzeug.datastructures import EnvironHeaders
+
 from odoo.exceptions import AccessError, ValidationError
 from odoo.tests.common import TransactionCase
+
+from odoo.addons.website.tools import MockRequest
 
 
 class TestAuthApiKey(TransactionCase):
@@ -68,3 +73,12 @@ class TestAuthApiKey(TransactionCase):
         self.assertEqual(
             self.env["auth.api.key"]._retrieve_uid_from_api_key("api_key"), demo_user.id
         )
+
+    def test_api_key_headers(self):
+        """The API key in the headers is read."""
+        with MockRequest(self.env) as mocked_request:
+            mocked_request.httprequest.environ["HTTP_API_KEY"] = self.api_key_good.key
+            mocked_request.httprequest.headers = EnvironHeaders(
+                mocked_request.httprequest.environ
+            )
+            self.assertTrue(self.env["ir.http"]._auth_method_api_key())


### PR DESCRIPTION
Without this change, the API key is not being read from the headers.

~~It seems very strange to me that this is not working, but in my case it isn't, please let me know if I'm missing something.~~
In the end, the problem was elsewhere, but I'll leave this here because it smells to have `headers = request.httprequest.environ`: the `request`'s `headers` should be assigned to the `headers` variable.