### PR TITLE
[17.0] impersonate_login: acl fix

### DIFF
--- a/impersonate_login/models/model.py
+++ b/impersonate_login/models/model.py
@@ -9,8 +9,17 @@ from odoo.http import request
 class BaseModel(models.AbstractModel):
     _inherit = "base"
 
+    def _keep_real_user_on_create_write(self):
+        # Avoid overriding the create_uid and write_uid
+        # when the model is abstract or transient
+        if self._abstract or self._transient:
+            return True
+        return False
+
     def _prepare_create_values(self, vals_list):
         result_vals_list = super()._prepare_create_values(vals_list)
+        if self._keep_real_user_on_create_write():
+            return result_vals_list
         if (
             request
             and request.session.impersonate_from_uid
@@ -23,6 +32,8 @@ class BaseModel(models.AbstractModel):
     def write(self, vals):
         """Overwrite the write_uid with the impersonating user"""
         res = super().write(vals)
+        if self._keep_real_user_on_create_write():
+            return res
         if (
             request
             and request.session.impersonate_from_uid

--- a/impersonate_login/models/model.py
+++ b/impersonate_login/models/model.py
@@ -12,7 +12,12 @@ class BaseModel(models.AbstractModel):
     def _keep_real_user_on_create_write(self):
         # Avoid overriding the create_uid and write_uid
         # when the model is abstract or transient
-        if self._abstract or self._transient:
+        # Keep core attachment access semantics intact.
+        # For temporary/generated attachments (often without res_model/res_id),
+        # read access falls back to creator ownership. Rewriting create_uid to
+        # the original impersonator can make the active impersonated user lose
+        # access immediately in the same flow (e.g. compose email after report).
+        if self._abstract or self._transient or self._name == "ir.attachment":
             return True
         return False
 

--- a/impersonate_login/tests/test_impersonate_login.py
+++ b/impersonate_login/tests/test_impersonate_login.py
@@ -263,3 +263,42 @@ class TestImpersonateLogin(HttpCase):
         self.assertEqual(contact.id, contact_id)
         self.assertEqual(contact.ref, "abc")
         self.assertEqual(contact.write_uid, self.admin_user)
+
+    def test_05_create_uid_on_transient_model(self):
+        """Check the create_uid of records created
+        during an impersonated session on a transient model"""
+        # Login as admin
+        self.authenticate(user="admin", password="admin")
+
+        # Impersonate demo user and create a wizard record
+        self._impersonate_user(self.demo_user)
+
+        response = self.url_open(
+            "/web/dataset/call_kw/mail.wizard.invite/web_save",
+            data=json.dumps(
+                {
+                    "params": {
+                        "model": "mail.wizard.invite",
+                        "method": "web_save",
+                        "args": [
+                            [],
+                            {
+                                "res_model": "res.partner",
+                                "message": "Hello",
+                            },
+                            {},
+                        ],
+                        "kwargs": {},
+                    },
+                }
+            ),
+            headers={"Content-Type": "application/json"},
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        result = data["result"]
+        settings_id = result[0]["id"]
+
+        wizard = self.env["mail.wizard.invite"].browse(settings_id)
+        self.assertIn("Hello", wizard.message)
+        self.assertEqual(wizard.create_uid, self.demo_user)


### PR DESCRIPTION
This cherry-picks https://github.com/OCA/server-auth/pull/913 and adapt https://github.com/OCA/server-auth/pull/907/ on top of it to address problems pointed in https://github.com/OCA/server-auth/issues/902

Currently, the module is very useful for admins/debugging to check things as a user, especially in highly secure environment where you can't just pick up user passwords (enforced 2FAs, etc). However, these ACL issues break a number of basic user flows (like simply uploading an attachment in a message), actually rendering this very unreliable.