### PR TITLE
[18.0][FIX] password_security: enforce configured per-character-class count

### DIFF
--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -119,10 +119,10 @@ class ResUsers(models.Model):
         pwd_params = self._get_all_password_params()
         password_regex = [
             "^",
-            "(?=.*?[a-z]){" + str(pwd_params["lower"]) + ",}",
-            "(?=.*?[A-Z]){" + str(pwd_params["upper"]) + ",}",
-            "(?=.*?\\d){" + str(pwd_params["numeric"]) + ",}",
-            r"(?=.*?[\W_]){" + str(pwd_params["special"]) + ",}",
+            "(?=(?:.*?[a-z]){" + str(pwd_params["lower"]) + ",})",
+            "(?=(?:.*?[A-Z]){" + str(pwd_params["upper"]) + ",})",
+            "(?=(?:.*?\\d){" + str(pwd_params["numeric"]) + ",})",
+            r"(?=(?:.*?[\W_]){" + str(pwd_params["special"]) + ",})",
             ".{%d,}$" % pwd_params["minlength"],
         ]
         if not re.search("".join(password_regex), password):

--- a/password_security/tests/test_res_users.py
+++ b/password_security/tests/test_res_users.py
@@ -149,6 +149,17 @@ class TestResUsers(TransactionCase):
         rec_id = self._new_record()
         rec_id._check_password("asdQWE12345_3")
 
+    def test_check_password_enforces_class_count(self):
+        """It should require the configured *count* of a character class"""
+        rec_id = self._new_record()
+        # Require two uppercase letters
+        self.env["ir.config_parameter"].sudo().set_param("password_security.upper", 2)
+        # Only one uppercase letter: must be rejected
+        with self.assertRaises(UserError):
+            rec_id._check_password("aSdqwe123$%^")
+        # Two uppercase letters: accepted
+        rec_id._check_password("aSDqwe123$%^")
+
     def test_user_with_admin_rights_can_create_users(self):
         demo = self.env.ref("base.user_demo")
         demo.groups_id |= self.env.ref("base.group_erp_manager")


### PR DESCRIPTION
## Bug

The per-character-class requirements (number of lowercase / uppercase / numeric / special characters) are not enforced beyond a single character.

`_check_password_rules` builds the policy regex from fragments like:

```python
"(?=.*?[A-Z]){" + str(pwd_params["upper"]) + ",}"
```

i.e. `(?=.*?[A-Z]){2,}`. The `{2,}` quantifier is applied to a **zero-width lookahead**, which is a no-op — the engine only needs the assertion to hold once — so any configured value ≥ 1 collapses to "at least one". Setting e.g. **Uppercase = 2** still accepts a password with a single uppercase letter (same for lowercase, numeric and special).

Minimum length is unaffected, because there the quantifier is applied to a real character (`.{N,}$`).

## Fix

Move the quantifier **inside** the lookahead group so it repeats the match:

```python
"(?=(?:.*?[A-Z]){" + str(pwd_params["upper"]) + ",})"
```

i.e. `(?=(?:.*?[A-Z]){2,})`, which actually requires 2 occurrences.

Adds a regression test (`test_check_password_enforces_class_count`).
