### PR TITLE
[18.0][FIX] password_security: treat an absent policy parameter as disabled

### DIFF
--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -40,16 +40,16 @@ class ResUsers(models.Model):
                 params.get_param("auth_password_policy.minlength", default=0)
             ),
             "expiration_days": int(
-                params.get_param("password_security.expiration_days", default=60)
+                params.get_param("password_security.expiration_days", default=0)
             ),
             "minimum_hours": int(
-                params.get_param("password_security.minimum_hours", default=60)
+                params.get_param("password_security.minimum_hours", default=0)
             ),
-            "history": int(params.get_param("password_security.history", default=30)),
-            "lower": int(params.get_param("password_security.lower", default=1)),
-            "upper": int(params.get_param("password_security.upper", default=1)),
-            "numeric": int(params.get_param("password_security.numeric", default=1)),
-            "special": int(params.get_param("password_security.special", default=1)),
+            "history": int(params.get_param("password_security.history", default=0)),
+            "lower": int(params.get_param("password_security.lower", default=0)),
+            "upper": int(params.get_param("password_security.upper", default=0)),
+            "numeric": int(params.get_param("password_security.numeric", default=0)),
+            "special": int(params.get_param("password_security.special", default=0)),
         }
         return res
 

--- a/password_security/tests/test_res_users.py
+++ b/password_security/tests/test_res_users.py
@@ -139,6 +139,18 @@ class TestResUsers(TransactionCase):
             rec_id._validate_pass_reset(),
         )
 
+    def test_absent_policy_param_disables_rule(self):
+        """An absent policy param disables the rule, not reverts to a default
+
+        The settings page deletes an ``ir.config_parameter`` when it is saved
+        as 0, so a missing param must read as 0 (disabled) rather than fall
+        back to a non-zero default. See OCA/server-auth#865.
+        """
+        icp = self.env["ir.config_parameter"].sudo()
+        icp.search([("key", "=", "password_security.upper")]).unlink()
+        params = self.model_obj._get_all_password_params()
+        self.assertEqual(params["upper"], 0)
+
     def test_underscore_is_special_character(self):
         password_special = int(
             self.env["ir.config_parameter"]


### PR DESCRIPTION
## Bug

`res.config.settings` deletes an `ir.config_parameter` when its integer field is saved as `0`. But `_get_all_password_params()` falls back to **non-zero defaults** when a parameter is missing:

```python
"minimum_hours": int(params.get_param("password_security.minimum_hours", default=60)),
"lower": int(params.get_param("password_security.lower", default=1)),
...
```

So setting e.g. **Minimum Hours** or **Uppercase** to `0` in the UI silently reverts to the old default — the rule can't actually be turned off, even though the settings page then shows `0`.

## Fix

Default every lookup to `0`, so an absent parameter disables its rule — which is exactly what the settings page already displays. The shipped defaults are still seeded by the `post_init` hook, so a fresh install behaves the same; this only changes what a *deleted / zeroed* parameter means.

Adds a regression test.

Refs #865 — this lets an admin actually disable the policy. It deliberately does **not** change the seeded install defaults; whether `password_security` should ship with no policy by default is a separate design question.
