### PR TITLE
[18.0][IMP] auth_saml: user provisioning on login

### DIFF
--- a/auth_saml/__manifest__.py
+++ b/auth_saml/__manifest__.py
@@ -1,12 +1,12 @@
 # Copyright (C) 2020 GlodoUK <https://www.glodo.uk/>
-# Copyright (C) 2010-2016, 2022 XCG Consulting <http://odoo.consulting>
+# Copyright (C) 2010-2016, 2022 XCG SAS <https://orbeet.io/>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     "name": "SAML2 Authentication",
     "version": "18.0.1.1.3",
     "category": "Tools",
-    "author": "XCG Consulting, Odoo Community Association (OCA)",
+    "author": "XCG SAS, Odoo Community Association (OCA)",
     "maintainers": ["vincent-hatakeyama"],
     "website": "https://github.com/OCA/server-auth",
     "license": "AGPL-3",

--- a/auth_saml/controllers/main.py
+++ b/auth_saml/controllers/main.py
@@ -1,14 +1,15 @@
 # Copyright (C) 2020 GlodoUK <https://www.glodo.uk/>
-# Copyright (C) 2010-2016, 2022-2023 XCG Consulting <https://xcg-consulting.fr/>
+# Copyright (C) 2010-2016, 2022-2023 XCG SAS <https://orbeet.io/>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import functools
 import json
 import logging
+from urllib.parse import quote_plus, unquote_plus, urlencode
 
 import werkzeug.utils
+from saml2.validate import ResponseLifetimeExceed
 from werkzeug.exceptions import BadRequest
-from werkzeug.urls import url_quote_plus
 
 from odoo import (
     SUPERUSER_ID,
@@ -98,7 +99,7 @@ class SAMLLogin(Home):
         redirect = request.params.get("redirect")
         if redirect:
             params["redirect"] = redirect
-        return f"/auth_saml/get_auth_request?{werkzeug.urls.url_encode(params)}"
+        return f"/auth_saml/get_auth_request?{urlencode(params)}"
 
     @http.route()
     def web_client(self, s_action=None, **kw):
@@ -134,6 +135,8 @@ class SAMLLogin(Home):
                 error = _("Sign up is not allowed on this database.")
             elif error == "access-denied":
                 error = _("Access Denied")
+            elif error == "response-lifetime-exceed":
+                error = _("Response Lifetime Exceeded")
             elif error == "expired":
                 error = _(
                     "You do not have access to this database. Please contact"
@@ -167,7 +170,7 @@ class AuthSAMLController(http.Controller):
             )
 
         state = {
-            "r": url_quote_plus(redirect),
+            "r": quote_plus(redirect),
         }
         return state
 
@@ -230,9 +233,7 @@ class AuthSAMLController(http.Controller):
             )
             action = state.get("a")
             menu = state.get("m")
-            redirect = (
-                werkzeug.urls.url_unquote_plus(state["r"]) if state.get("r") else False
-            )
+            redirect = unquote_plus(state["r"]) if state.get("r") else False
             url = "/web"
             if redirect:
                 url = redirect
@@ -258,6 +259,9 @@ class AuthSAMLController(http.Controller):
             redirect = werkzeug.utils.redirect(url, 303)
             redirect.autocorrect_location_header = False
             return redirect
+        except ResponseLifetimeExceed as e:
+            _logger.debug("Response Lifetime Exceed - %s", str(e))
+            url = "/web/login?saml_error=response-lifetime-exceed"
 
         except Exception as e:
             # signup error

--- a/auth_saml/models/auth_saml_attribute_mapping.py
+++ b/auth_saml/models/auth_saml_attribute_mapping.py
@@ -13,6 +13,7 @@ class AuthSamlAttributeMapping(models.Model):
         "auth.saml.provider",
         index=True,
         required=True,
+        ondelete="cascade",
     )
     attribute_name = fields.Char(
         string="IDP Response Attribute",

--- a/auth_saml/models/auth_saml_provider.py
+++ b/auth_saml/models/auth_saml_provider.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020 Glodo UK <https://www.glodo.uk/>
-# Copyright (C) 2010-2016, 2022 XCG Consulting <https://xcg-consulting.fr/>
+# Copyright (C) 2010-2016, 2022, 2025-2026 XCG SAS <https://orbeet.io/>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import base64
@@ -93,6 +93,7 @@ class AuthSamlProvider(models.Model):
         "auth.saml.attribute.mapping",
         "provider_id",
         string="Attribute Mapping",
+        copy=True,
     )
     active = fields.Boolean(default=True)
     sequence = fields.Integer(index=True)
@@ -147,6 +148,28 @@ class AuthSamlProvider(models.Model):
     sign_metadata = fields.Boolean(
         default=True,
         help="Whether metadata should be signed or not",
+    )
+    # User creation fields
+    create_user = fields.Boolean(
+        default=False,
+        help="Create user if not found. The login and name will defaults to the SAML "
+        "user matching attribute. Use the mapping attributes to change the value "
+        "used. If a deactivated user has a matching saml uid, activate it rather than"
+        "create a new one.",
+    )
+    create_user_template_id = fields.Many2one(
+        comodel_name="res.users",
+        # Template users, like base.default_user, are disabled by default so allow them
+        domain="[('active', 'in', (True, False))]",
+        default=lambda self: self.env.ref("base.default_user"),
+        help="When creating user, this user is used as a template",
+    )
+    create_user_reactivate = fields.Boolean(
+        "Reactivate when Creating Users",
+        default=False,
+        help="If a deactivated user has a matching SAML uid when trying to create the "
+        "user, and this is checked, then the user is reactivated. Otherwise,"
+        "access is denied.",
     )
 
     @api.model
@@ -277,9 +300,7 @@ class AuthSamlProvider(models.Model):
         }
         state.update(extra_state)
 
-        sig_alg = ds.SIG_RSA_SHA1
-        if self.sig_alg:
-            sig_alg = getattr(ds, self.sig_alg)
+        sig_alg = getattr(ds, self.sig_alg)
 
         saml_client = self._get_client_for_provider(url_root)
         reqid, info = saml_client.prepare_for_authenticate(
@@ -293,6 +314,7 @@ class AuthSamlProvider(models.Model):
         for key, value in info["headers"]:
             if key == "Location":
                 redirect_url = value
+                break
 
         self._store_outstanding_request(reqid)
 
@@ -321,27 +343,15 @@ class AuthSamlProvider(models.Model):
                 )
             else:
                 raise
-        matching_value = None
-
-        if self.matching_attribute == "subject.nameId":
-            matching_value = response.name_id.text
-        else:
-            attrs = response.get_identity()
-
-            for k, v in attrs.items():
-                if k == self.matching_attribute:
-                    matching_value = v
-                    break
-
-            if not matching_value:
-                raise Exception(
-                    f"Matching attribute {self.matching_attribute} not found "
-                    f"in user attrs: {attrs}"
-                )
-
-        if matching_value and isinstance(matching_value, list):
-            matching_value = next(iter(matching_value), None)
-
+        try:
+            matching_value = self._get_attribute_value(
+                response, self.matching_attribute
+            )
+        except KeyError:
+            raise KeyError(
+                f"Matching attribute {self.matching_attribute} not found "
+                f"in user attrs: {response.get_identity()}"
+            ) from None
         if isinstance(matching_value, str) and self.matching_attribute_to_lower:
             matching_value = matching_value.lower()
 
@@ -383,25 +393,39 @@ class AuthSamlProvider(models.Model):
             sign=self.sign_metadata,
         )
 
+    @staticmethod
+    def _get_attribute_value(response, attribute_name: str):
+        """
+
+        :raise: KeyError if attribute is not in the response
+        :param response:
+        :param attribute_name:
+        :return: value of the attribute. if the value is an empty list, return None
+                 otherwise return the first element of the list
+        """
+        if attribute_name == "subject.nameId":
+            return response.name_id.text
+        attrs = response.get_identity()
+        attribute_value = attrs[attribute_name]
+        if isinstance(attribute_value, list):
+            attribute_value = next(iter(attribute_value), None)
+        return attribute_value
+
     def _hook_validate_auth_response(self, response, matching_value):
         self.ensure_one()
         vals = {}
-        attrs = response.get_identity()
 
         for attribute in self.attribute_mapping_ids:
-            if attribute.attribute_name not in attrs:
-                _logger.debug(
+            try:
+                vals[attribute.field_name] = self._get_attribute_value(
+                    response, attribute.attribute_name
+                )
+            except KeyError:
+                _logger.warning(
                     "SAML attribute '%s' not found in response %s",
                     attribute.attribute_name,
-                    attrs,
+                    response.get_identity(),
                 )
-                continue
-
-            attribute_value = attrs[attribute.attribute_name]
-            if isinstance(attribute_value, list):
-                attribute_value = attribute_value[0]
-
-            vals[attribute.field_name] = attribute_value
 
         return {"mapped_attrs": vals}
 
@@ -444,3 +468,24 @@ class AuthSamlProvider(models.Model):
                 updated = True
 
         return updated
+
+    def _user_copy_defaults(self, validation):
+        """
+        Returns defaults when copying the template user.
+
+        Can be overridden with extra information.
+        :param validation: validation result
+        :return: a dictionary for copying template user, empty to avoid copying
+        """
+        self.ensure_one()
+        if not self.create_user:
+            return {}
+        saml_uid = validation["user_id"]
+        return {
+            "name": saml_uid,
+            "login": saml_uid,
+            "active": True,
+            # if signature is not provided by mapped_attrs, it will be computed
+            # due to call to compute method in calling method.
+            "signature": None,
+        } | validation.get("mapped_attrs", {})

--- a/auth_saml/models/auth_saml_request.py
+++ b/auth_saml/models/auth_saml_request.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020 GlodoUK <https://glodo.uk/>
-# Copyright (C) 2022 XCG Consulting <https://xcg-consulting.fr/>
+# Copyright (C) 2022 XCG SAS <https://orbeet.io/>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models

--- a/auth_saml/models/ir_config_parameter.py
+++ b/auth_saml/models/ir_config_parameter.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 XCG Consulting <https://xcg-consulting.fr/>
+# Copyright (C) 2022 XCG SAS <https://orbeet.io/>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import logging
 

--- a/auth_saml/models/res_config_settings.py
+++ b/auth_saml/models/res_config_settings.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2010-2016, 2022 XCG Consulting <http://odoo.consulting>
+# Copyright (C) 2010-2016, 2022 XCG SAS <https://orbeet.io/>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models

--- a/auth_saml/models/res_users.py
+++ b/auth_saml/models/res_users.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2020 GlodoUK <https://www.glodo.uk>
-# Copyright (C) 2010-2016 XCG Consulting <http://odoo.consulting>
+# Copyright (C) 2010-2016 XCG SAS <http://orbeet.io/>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
@@ -7,7 +7,7 @@ from typing import Set  # noqa
 
 import passlib
 
-from odoo import SUPERUSER_ID, _, api, fields, models, modules, tools
+from odoo import SUPERUSER_ID, Command, _, api, fields, models, modules, tools
 from odoo.exceptions import AccessDenied, ValidationError
 
 from .ir_config_parameter import ALLOW_SAML_UID_AND_PASSWORD
@@ -44,12 +44,43 @@ class ResUser(models.Model):
             [("saml_uid", "=", saml_uid), ("saml_provider_id", "=", provider)],
             limit=1,
         )
+        saml_provider = self.env["auth.saml.provider"].browse(provider)
         user = user_saml.user_id
-        if len(user) != 1:
-            raise AccessDenied()
+        user_copy_defaults = {}
+        if not user.active and saml_provider.create_user:
+            if saml_provider.create_user_reactivate:
+                user.active = True
+        if not user:
+            user_copy_defaults = saml_provider._user_copy_defaults(validation)
+            if not user_copy_defaults:
+                raise AccessDenied()
 
         with modules.registry.Registry(self.env.cr.dbname).cursor() as new_cr:
             new_env = api.Environment(new_cr, self.env.uid, self.env.context)
+            if user_copy_defaults:
+                new_user = (
+                    new_env["auth.saml.provider"]
+                    .browse(provider)
+                    .create_user_template_id.with_context(no_reset_password=True)
+                    .copy(
+                        {
+                            **user_copy_defaults,
+                            "saml_ids": [
+                                Command.create(
+                                    {
+                                        "saml_provider_id": provider,
+                                        "saml_uid": saml_uid,
+                                        "saml_access_token": saml_response,
+                                    }
+                                )
+                            ],
+                        }
+                    )
+                )
+                # Update signature as needed.
+                new_user._compute_signature()
+                return new_user.login
+
             # Update the token. Need to be committed, otherwise the token is not visible
             # to other envs, like the one used in login_and_redirect
             user_saml.with_env(new_env).write({"saml_access_token": saml_response})

--- a/auth_saml/models/res_users_saml.py
+++ b/auth_saml/models/res_users_saml.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 XCG Consulting <https://xcg-consulting.fr/>
+# Copyright (C) 2022 XCG SAS <https://orbeet.io/>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import api, fields, models
 
@@ -7,7 +7,9 @@ class ResUserSaml(models.Model):
     _name = "res.users.saml"
     _description = "User to SAML Provider Mapping"
 
-    user_id = fields.Many2one("res.users", index=True, required=True)
+    user_id = fields.Many2one(
+        "res.users", index=True, required=True, ondelete="cascade"
+    )
     saml_provider_id = fields.Many2one(
         "auth.saml.provider", string="SAML Provider", index=True
     )

--- a/auth_saml/readme/CONFIGURE.md
+++ b/auth_saml/readme/CONFIGURE.md
@@ -2,7 +2,8 @@ To use this module, you need an IDP server, properly set up.
 
 1.  Configure the module according to your IdP’s instructions (Settings
     \> Users & Companies \> SAML Providers).
-2.  Pre-create your users and set the SAML information against the user.
+2.  Pre-create your users and set the SAML information against the user,
+    or use the module ability to create users as they log in.
 
 By default, the module let users have both a password and SAML ids. To
 increase security, disable passwords by using the option in Settings.

--- a/auth_saml/readme/CONTRIBUTORS.md
+++ b/auth_saml/readme/CONTRIBUTORS.md
@@ -1,9 +1,9 @@
-- [XCG Consulting](https://xcg-consulting.fr/):
-  - Florent Aide \<<florent.aide@xcg-consulting.fr>\>
-  - Vincent Hatakeyama \<<vincent.hatakeyama@xcg-consulting.fr>\>
+- XCG SAS part of [Orbeet](https://orbeet.io/):
+  - Florent Aide \<<florent.aide@orbeet.io>\>
+  - Vincent Hatakeyama \<<vincent.hatakeyama@orbeet.io>\>
   - Alexandre Brun
-  - Houzéfa Abbasbhay \<<houzefa.abba@xcg-consulting.fr>\>
-  - Szeka Wong \<<szeka.wong@xcg-consulting.fr>\>
+  - Houzéfa Abbasbhay \<<houzefa.abba@orbeet.io>\>
+  - Szeka Wong \<<szeka.wong@orbeet.io>\>
 - Jeremy Co Kim Len \<<jeremy.cokimlen@vinci-concessions.com>\>
 - Jeffery Chen Fan \<<jeffery9@gmail.com>\>
 - Bhavesh Odedra \<<bodedra@opensourceintegrators.com>\>

--- a/auth_saml/readme/newsfragments/+user-creation.feature
+++ b/auth_saml/readme/newsfragments/+user-creation.feature
@@ -1,0 +1,6 @@
+- custom message when response is too old
+- avoid using werkzeug.urls method, they are deprecated
+- add missing ondelete cascade when user is deleted
+- attribute mapping is now also duplicated when the provider is duplicated
+- factorize getting SAML attribute value, allowing using subject.nameId in mapping attributes too
+- allow creating user if not found by copying a template user, or activating a deactivated user.

--- a/auth_saml/tests/fake_idp.py
+++ b/auth_saml/tests/fake_idp.py
@@ -71,13 +71,21 @@ CONFIG = {
 }
 
 
+class DummyNameId:
+    """Dummy name id with text value"""
+
+    def __init__(self, text):
+        self.text = text
+
+
 class DummyResponse:
-    def __init__(self, status, data, headers=None):
+    def __init__(self, status, data, headers=None, name_id: str = ""):
         self.status_code = status
         self.text = data
         self.headers = headers or []
         self.content = data
         self._identity = {}
+        self.name_id = DummyNameId(name_id)
 
     def _unpack(self, ver="SAMLResponse"):
         """
@@ -126,6 +134,7 @@ class FakeIDP(Server):
         config.load(settings)
         config.allow_unknown_attributes = True
         Server.__init__(self, config=config)
+        self.mail = "test@example.com"
 
     def get_metadata(self):
         return create_metadata_string(
@@ -159,7 +168,7 @@ class FakeIDP(Server):
             "surName": "Example",
             "givenName": "Test",
             "title": "Ind",
-            "mail": "test@example.com",
+            "mail": self.mail,
         }
 
         resp_args.update({"sign_assertion": True, "sign_response": True})

--- a/auth_saml/tests/test_pysaml.py
+++ b/auth_saml/tests/test_pysaml.py
@@ -1,4 +1,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# Copyright (C) 2025-2026 XCG SAS <https://orbeet.io/>
 import base64
 import html
 import os
@@ -114,6 +115,8 @@ class TestPySaml(HttpCase):
 
     def test__onchange_name(self):
         temp = self.saml_provider.body
+        r = self.saml_provider._onchange_name()
+        self.assertEqual(self.saml_provider.body, temp)
         self.saml_provider.body = ""
         r = self.saml_provider._onchange_name()
         self.assertEqual(r, None)
@@ -166,9 +169,10 @@ class TestPySaml(HttpCase):
         )
         self._add_mapping_to_provider()
         # Call the method
-        result = self.saml_provider._hook_validate_auth_response(
-            fake_response, "test@example.com"
-        )
+        with mute_logger("odoo.addons.auth_saml.models.auth_saml_provider"):
+            result = self.saml_provider._hook_validate_auth_response(
+                fake_response, "test@example.com"
+            )
 
         # Check the result
         self.assertIn("mapped_attrs", result)
@@ -252,7 +256,9 @@ class TestPySaml(HttpCase):
 
     def test_login_with_saml(self):
         self.add_provider_to_user()
+        self._login_with_saml()
 
+    def _login_with_saml(self):
         redirect_url = self.saml_provider._get_auth_request()
         self.assertIn("http://localhost:8000/sso/redirect?SAMLRequest=", redirect_url)
 
@@ -269,7 +275,7 @@ class TestPySaml(HttpCase):
         )
 
         self.assertEqual(database, self.env.cr.dbname)
-        self.assertEqual(login, self.user.login)
+        self.assertEqual(login, "test@example.com")
 
         # We should not be able to log in with the wrong token
         with self.assertRaises(AccessDenied):
@@ -291,6 +297,42 @@ class TestPySaml(HttpCase):
         self.assertEqual(self.user.name, "Test")
         # Not changed
         self.assertEqual(self.user.login, "test@example.com")
+
+    def test_login_with_saml_mapping_attributes_subject(self):
+        """Test login with SAML on a provider with mapping attributes"""
+        self.assertEqual(self.user.email, "test@example.com")
+        self.saml_provider.attribute_mapping_ids = [
+            (0, 0, {"attribute_name": "subject.nameId", "field_name": "email"}),
+        ]
+        self.test_login_with_saml()
+        # The value is changed, but FakeIDP returns a random value so
+        # only test that the value is changed.
+        self.assertNotEqual(self.user.email, "test@example.com")
+
+    def test_login_with_saml_to_lower(self):
+        self.add_provider_to_user()
+        self.saml_provider.matching_attribute_to_lower = True
+        self.idp.mail = "TEST@example.com"
+        self._login_with_saml()
+
+    def test_login_with_saml_non_existing_mapping_attribute(self):
+        self.saml_provider.matching_attribute = "nick_name"
+        self.add_provider_to_user()
+        with self.assertRaises(KeyError):
+            self._login_with_saml()
+
+    def test_create_user(self):
+        self.user.unlink()
+        self.saml_provider.create_user = True
+        self._login_with_saml()
+        self.user = self.env["res.users"].search([("login", "=", "test@example.com")])
+        # Disable user and check that it is not enabled
+        self.user.active = False
+        with self.assertRaises(AccessDenied):
+            self._login_with_saml()
+        self.saml_provider.create_user_reactivate = True
+        self._login_with_saml()
+        self.assertTrue(self.user.active)
 
     def test_disallow_user_password_when_changing_ir_config_parameter(self):
         """Test that disabling users from having both a password and SAML ids remove
@@ -337,9 +379,10 @@ class TestPySaml(HttpCase):
         """Test that a new user with SAML ids can not have its password set up when the
         disallow option is set."""
         # change the option
-        self.browse_ref(
-            "auth_saml.allow_saml_uid_and_internal_password"
-        ).value = "False"
+        self.browse_ref("auth_saml.allow_saml_uid_and_internal_password").unlink()
+        self.env["ir.config_parameter"].set_param(
+            "auth_saml.allow_saml_uid_and_internal_password", "False"
+        )
         # Create a new user with only SAML ids
         user = (
             self.env["res.users"]
@@ -374,11 +417,38 @@ class TestPySaml(HttpCase):
         self.browse_ref(
             "auth_saml.allow_saml_uid_and_internal_password"
         ).value = "False"
+        # Test that existing user password still works if no saml uid is set
+        self.authenticate(user="test@example.com", password="Lu,ums-7vRU>0i]=YDLa")
+        # Test that existing user password is deleted when adding an SAML provider
+        self.add_provider_to_user()
         with self.assertRaises(AccessDenied):
             self.user._check_credentials(
                 {"type": "password", "password": "Lu,ums-7vRU>0i]=YDLa"},
                 {"interactive": True},
             )
+
+    def test_disallow_user_password_unlink(self):
+        """Test that existing user password is deleted when adding an SAML provider when
+        the disallow option is not present (and defaults to false)."""
+        # change the option
+        self.browse_ref("auth_saml.allow_saml_uid_and_internal_password").unlink()
+        # Test that existing user password still works if no saml uid is set
+        self.authenticate(user="test@example.com", password="Lu,ums-7vRU>0i]=YDLa")
+        # Test that existing user password is deleted when adding an SAML provider
+        self.add_provider_to_user()
+        with self.assertRaises(AccessDenied):
+            self.authenticate(user="test@example.com", password="Lu,ums-7vRU>0i]=YDLa")
+
+    def test_change_unrelated_ir_config_parameter(self):
+        """Test another branch, creating or writing another ir.config_parameter"""
+        param = self.env["ir.config_parameter"].create(
+            [{"key": "test", "value": "unrelated"}]
+        )
+        self.authenticate(user="test@example.com", password="Lu,ums-7vRU>0i]=YDLa")
+        self.env["ir.config_parameter"].set_param("test", "False")
+        self.authenticate(user="test@example.com", password="Lu,ums-7vRU>0i]=YDLa")
+        param.unlink()
+        self.authenticate(user="test@example.com", password="Lu,ums-7vRU>0i]=YDLa")
 
     def test_disallow_user_admin_can_have_password(self):
         """Test that admin can have its password set

--- a/auth_saml/views/auth_saml.xml
+++ b/auth_saml/views/auth_saml.xml
@@ -197,6 +197,21 @@
                             <field name="body" />
                             <field name="css_class" />
                         </group>
+                        <group
+                            string="User Creation Settings"
+                            name="create_user_settings"
+                        >
+                            <field name="create_user" />
+                            <field
+                                name="create_user_template_id"
+                                string="User Template"
+                            />
+                            <field
+                                name="create_user_reactivate"
+                                invisible="not create_user"
+                                string="Reactivate"
+                            />
+                        </group>
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
- custom message when response is too old
- avoid using werkzeug.urls method, they are deprecated
- add missing ondelete cascade when user is deleted
- attribute mapping is now also duplicated when the provider is duplicated
- factorize getting SAML attribute value, allowing using subject.nameId in mapping attributes too
- add an opton to reactivate user when finding an user and creation is enabled

Forward port of #695