### PR TITLE
[18.0][FIX] password_security: Fix expected singleton

### DIFF
--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -78,7 +78,6 @@ class ResUsers(models.Model):
         return result
 
     def password_match_message(self):
-        self.ensure_one()
         message = []
         pwd_params = self._get_all_password_params()
         if pwd_params["lower"]:
@@ -113,7 +112,6 @@ class ResUsers(models.Model):
         return True
 
     def _check_password_rules(self, password):
-        self.ensure_one()
         if not password:
             return True
         pwd_params = self._get_all_password_params()

--- a/password_security/tests/test_change_password.py
+++ b/password_security/tests/test_change_password.py
@@ -1,6 +1,6 @@
 # Copyright 2023 Onestein (<https://www.onestein.eu>)
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
-
+import re
 from unittest import mock
 
 from odoo import http
@@ -134,3 +134,14 @@ class TestPasswordSecurityChange(HttpCase):
         # Log in with new password: ensure we end up on the right page
         res_login2 = self.login("admin", "!asdQWE12345_4")
         self.assertEqual(res_login2.request.path_url, "/odoo")
+
+    def test_20_write_password(self):
+        """Detects expected singleton errors writing passwords for more than one user"""
+        users = self.env["res.users"].search([], limit=2)
+        self.assertEqual(len(users), 2)
+        res = users.write({"password": "!asdQWE12345"})
+        self.assertTrue(res)
+
+        msg = re.escape(users[0].password_match_message())
+        with self.assertRaisesRegex(ValidationError, msg):
+            users.write({"password": "12345678"})


### PR DESCRIPTION
Forward-port of #961 to 18.0.

When updating the password for more than one user, ensure_one() raises an expected singleton error.

This keeps the same minimal approach used in 17.0:
- remove ensure_one() from password_match_message()
- remove ensure_one() from _check_password_rules()
- add a regression test for multi-user password write

cc @moylop260