### PR TITLE
[18.0][FIX] password_security: sudo password history read for reuse

### DIFF
--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -175,11 +175,13 @@ class ResUsers(models.Model):
         pwd_params = self._get_all_password_params()
         for user in self:
             if not pwd_params["history"]:  # disabled
-                recent_passes = self.env["res.users.pass.history"]
+                recent_passes = self.sudo().env["res.users.pass.history"]
             elif pwd_params["history"] < 0:  # unlimited
-                recent_passes = user.password_history_ids
+                recent_passes = user.sudo().password_history_ids
             else:
-                recent_passes = user.password_history_ids[: pwd_params["history"]]
+                recent_passes = user.sudo().password_history_ids[
+                    : pwd_params["history"]
+                ]
             if recent_passes.filtered(
                 lambda r: crypt.verify(password, r.password_crypt)
             ):


### PR DESCRIPTION
The `res.users.pass.history` record rules only let a user read their own history. So when someone set another user's password (an admin resetting it), `_check_password_history` read an empty history and the "cannot reuse recent passwords" check was silently skipped. Reading the history with `sudo()` fixes this, the check sees the target's real history regardless of who triggers the change.
