### PR TITLE
[18.0][FIX] vault: generate keys on first usage instead of failing

### DIFF
--- a/vault/static/src/backend/vault.esm.js
+++ b/vault/static/src/backend/vault.esm.js
@@ -119,9 +119,12 @@ const vaultService = {
                 const store = await this._get_object_store();
                 store.clear();
 
-                // Import the keys from the database
-                if (!(await this._import_from_database()))
-                    throw Error(_t("Failed to import keys from database"));
+                // Import the keys from the database or generate them if missing
+                if (!(await this._import_from_database())) {
+                    if (await this._check_database())
+                        throw Error(_t("Failed to import keys from database"));
+                    return await this.generate_keys();
+                }
 
                 // Store the imported keys in the object store for the next calls
                 if (!(await this._export_to_store()))

--- a/vault/static/tests/vault_tests.esm.js
+++ b/vault/static/tests/vault_tests.esm.js
@@ -130,6 +130,21 @@ QUnit.module(
             is_keypair(vault.keys, assert);
         });
 
+        QUnit.test(
+            "vault: Test key generation on first usage",
+            async function (assert) {
+                assert.expect(4);
+
+                const env = await makeTestEnv({activateMockServer: true});
+                var vault = env.services.vault;
+
+                // A first-time user has no keys yet. Accessing the public key
+                // must generate them instead of throwing.
+                await vault.get_public_key();
+                is_keypair(vault.keys, assert);
+            }
+        );
+
         QUnit.test("vault: Importer/exporter", async function (assert) {
             // The exporter won't skip empty keys
             const child = {


### PR DESCRIPTION
_ensure_keys() threw 'Failed to import keys from database' for a first-time user with no key pair yet (e.g. opening the vault module and pressing New then Save). It now generates a new key pair when none exist in the database, matching the fallback already present in _initialize_keys(). A genuine import failure with existing keys still raises the error. Added a QUnit test covering the first-usage flow.