### PR TITLE
[18.0][FIX] vault: remove 'New' button from user search dialog when sharing

### DIFF
--- a/vault/views/vault_right_views.xml
+++ b/vault/views/vault_right_views.xml
@@ -8,7 +8,10 @@
                 <field name="master_key" column_invisible="1" />
                 <field name="key" column_invisible="1" />
                 <field name="public_key" column_invisible="1" />
-                <field name="user_id" />
+                <field
+                    name="user_id"
+                    options="{'no_create': True, 'no_quick_create': True, 'no_create_edit': True}"
+                />
                 <field name="perm_create" />
                 <field name="perm_write" />
                 <field name="perm_share" />
@@ -23,7 +26,10 @@
             <form>
                 <sheet>
                     <group>
-                        <field name="user_id" />
+                        <field
+                            name="user_id"
+                            options="{'no_create': True, 'no_quick_create': True, 'no_create_edit': True}"
+                        />
                         <field name="perm_create" />
                         <field name="perm_write" />
                         <field name="perm_share" />


### PR DESCRIPTION
When sharing a vault, the user search dialog offered a 'New' button to create a new user. This does not make sense because the target user must first manually create a key in their own profile before a vault can be shared with them.