### PR TITLE
[18.0][FIX] vault: field names

### DIFF
--- a/vault/views/res_config_settings_views.xml
+++ b/vault/views/res_config_settings_views.xml
@@ -16,15 +16,15 @@
                     </setting>
                     <setting
                         help="Allow all users to import vaults accessible to them"
-                        id="vault_share"
+                        id="vault_import"
                     >
                         <field name="group_vault_import" />
                     </setting>
                     <setting
                         help="Allow all users to export vaults accessible to them"
-                        id="vault_share"
+                        id="vault_export"
                     >
-                        <field name="group_vault_import" />
+                        <field name="group_vault_export" />
                     </setting>
                 </block>
             </block>


### PR DESCRIPTION
Fixes field names being displayed wrongly in Settings.

<img width="888" height="252" alt="grafik" src="https://github.com/user-attachments/assets/6348221b-9f3e-4a59-b281-4b57bfd862f3" />
