### PR TITLE
[18.0][FIX] vault: mark inbox route as website to fix KeyError: 'website'

### DIFF
--- a/vault/controllers/main.py
+++ b/vault/controllers/main.py
@@ -11,7 +11,7 @@ _logger = logging.getLogger(__name__)
 
 
 class Controller(http.Controller):
-    @http.route("/vault/inbox/<string:token>", type="http", auth="public")
+    @http.route("/vault/inbox/<string:token>", type="http", auth="public", website=True)
     def vault_inbox(self, token):
         ctx = {"disable_footer": True, "token": token}
         # Find the right token


### PR DESCRIPTION
The /vault/inbox/<token> route renders the vault.inbox template which calls web.login_layout. When the website module is installed it overrides web.login_layout to render website.layout, which requires the 'website' value in the render context. That value is only injected when the request is flagged as a frontend request (request.is_frontend), which in turn is derived from the route's website=True flag. Without it, rendering the shared-secret page crashed with KeyError: 'website'.