### PR TITLE
[18.0][FIX] vault: avoid singleton error on batched vault.right create

### DIFF
--- a/vault/models/vault_right.py
+++ b/vault/models/vault_right.py
@@ -88,7 +88,7 @@ class VaultRight(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         res = super().create(vals_list)
-        if not res.allowed_share and not res.env.su:
+        if not res.env.su and res.filtered(lambda r: not r.allowed_share):
             self.raise_access_error()
 
         res.log_access()

--- a/vault/tests/test_rights.py
+++ b/vault/tests/test_rights.py
@@ -157,3 +157,42 @@ class TestAccessRights(BaseCommon):
         right.with_user(self.user).create({"vault_id": self.vault.id, "user_id": 2})
 
         right.unlink()
+
+    def test_batch_create(self):
+        # Batched create must not raise a singleton error
+        other_user = new_test_user(self.env, login="test-vault-user-2")
+        rights = self.env["vault.right"].create(
+            [
+                {"vault_id": self.vault.id, "user_id": self.user.id},
+                {"vault_id": self.vault.id, "user_id": other_user.id},
+            ]
+        )
+        self.assertEqual(len(rights), 2)
+
+    def test_batch_create_no_permission(self):
+        # Batched create by a user without share permission must be denied
+        self.env["vault.right"].create(
+            {"vault_id": self.vault.id, "user_id": self.user.id, "perm_share": False}
+        )
+        with self.assertRaises(AccessError):
+            self.env["vault.right"].with_user(self.user).create(
+                [
+                    {"vault_id": self.vault.id, "user_id": 2},
+                    {"vault_id": self.vault.id, "user_id": 3},
+                ]
+            )
+
+    def test_sudo_create_bypasses_share_check(self):
+        # As superuser the share-permission guard is bypassed
+        right = (
+            self.env["vault.right"]
+            .sudo()
+            .create(
+                {
+                    "vault_id": self.vault.id,
+                    "user_id": self.user.id,
+                    "perm_share": False,
+                }
+            )
+        )
+        self.assertTrue(right)


### PR DESCRIPTION
A batched create() results in several records and the guard accessed the non-stored related field allowed_share on the whole set, triggering ensure_one() -> 'Expected singleton: vault.right(...)'.