### PR TITLE
[18.0][FIX] vault: inbox share form token handling and optional file

### DIFF
--- a/vault/controllers/main.py
+++ b/vault/controllers/main.py
@@ -19,12 +19,16 @@ class Controller(http.Controller):
         user = request.env["res.users"].sudo().find_user_of_inbox(token)
         if len(inbox) == 1 and inbox.accesses > 0:
             ctx.update({"name": inbox.name, "public": inbox.user_id.active_key.public})
-        elif len(inbox) == 0 and len(user) == 1:
+        elif len(user) == 1:
             ctx["public"] = user.active_key.public
-
-        # A valid token would mean we found a public key
-        if not ctx.get("public"):
+        else:
+            # The token doesn't match any inbox or user
             ctx["error"] = _("Invalid token")
+            return request.render("vault.inbox", ctx)
+
+        # The token is valid but the recipient has no key pair to encrypt for
+        if not ctx.get("public"):
+            ctx["error"] = _("The recipient has not set up a vault key yet")
             return request.render("vault.inbox", ctx)
 
         # Just render if GET method

--- a/vault/static/src/frontend/inbox.esm.js
+++ b/vault/static/src/frontend/inbox.esm.js
@@ -63,6 +63,8 @@ document.getElementById("secret").onchange = async function () {
     toggle_required(data.secret, required);
     toggle_required(data.secret_file, !required);
     data.submit.removeAttribute("disabled");
+    data.secret.setCustomValidity("");
+    data.secret_file.setCustomValidity("");
 };
 
 document.getElementById("secret_file").onchange = async function () {
@@ -92,4 +94,29 @@ document.getElementById("secret_file").onchange = async function () {
     toggle_required(data.secret_file, required);
     data.filename.value = file.name;
     data.submit.removeAttribute("disabled");
+    data.secret.setCustomValidity("");
+    data.secret_file.setCustomValidity("");
+};
+
+// Ensure that at least one of the fields is provided before submitting.
+document.getElementById("submit").closest("form").onsubmit = function (ev) {
+    this.action += location.hash;
+
+    if (!utils.supported()) return true;
+
+    for (const id of fields) if (!data[id]) data[id] = document.getElementById(id);
+
+    const has_secret = data.secret.value || data.encrypted.value;
+    const has_file = data.secret_file.value || data.encrypted_file.value;
+
+    if (!has_secret && !has_file) {
+        data.secret.setCustomValidity("Please enter a secret or attach a file.");
+        data.secret.reportValidity();
+        ev.preventDefault();
+        return false;
+    }
+
+    data.secret.setCustomValidity("");
+    data.secret_file.setCustomValidity("");
+    return true;
 };

--- a/vault/tests/test_controller.py
+++ b/vault/tests/test_controller.py
@@ -68,6 +68,16 @@ class TestController(BaseCommon):
             self.assertNotIn("error", response)
             self.assertEqual(response["public"], self.user.active_key.public)
 
+            keyless = self.env["res.users"].create(
+                {"login": "keyless", "email": "k@k", "name": "keyless"}
+            )
+            keyless.inbox_token = "no-key-token"
+            keyless.keys.current = False
+            response = load(self.controller.vault_inbox("no-key-token"))
+            self.assertEqual(
+                response["error"], "The recipient has not set up a vault key yet"
+            )
+
             # Try to eliminate each error step by step
             request_mock.httprequest.method = "POST"
             request_mock.params = {}

--- a/vault/views/templates.xml
+++ b/vault/views/templates.xml
@@ -9,7 +9,6 @@
                 role="form"
                 t-attf-action="/vault/inbox/{{ token }}"
                 method="post"
-                onsubmit="this.action = this.action + location.hash"
             >
                 <input
                     type="hidden"
@@ -51,7 +50,6 @@
                         type="text"
                         id="secret"
                         name="secret"
-                        required="required"
                         autofocus="autofocus"
                         class="form-control"
                     />
@@ -64,7 +62,6 @@
                         placeholder="Secret"
                         id="secret_file"
                         name="secret_file"
-                        required="required"
                         class="form-control"
                     />
                 </div>


### PR DESCRIPTION
The frontend inbox share form showed 'Invalid token' for valid links and wrongly required a file even when a name and secret were provided.