### PR TITLE
[18.0][FIX] vault: show clear message on wrong unlock password

### DIFF
--- a/vault/static/src/backend/vault.esm.js
+++ b/vault/static/src/backend/vault.esm.js
@@ -341,13 +341,23 @@ const vaultService = {
                         this.iterations
                     );
 
-                    this.keys = {
-                        publicKey: await vault_utils.load_public_key(params.public),
-                        privateKey: await vault_utils.load_private_key(
+                    let private_key = null;
+                    try {
+                        private_key = await vault_utils.load_private_key(
                             params.private,
                             pass,
                             params.iv
-                        ),
+                        );
+                    } catch (error) {
+                        console.error(error);
+                        throw new Error(
+                            _t("The entered password is wrong. Please try again.")
+                        );
+                    }
+
+                    this.keys = {
+                        publicKey: await vault_utils.load_public_key(params.public),
+                        privateKey: private_key,
                     };
 
                     this.time = new Date();

--- a/vault/static/tests/vault_tests.esm.js
+++ b/vault/static/tests/vault_tests.esm.js
@@ -112,6 +112,26 @@ QUnit.module(
             assert.deepEqual(master_key, tmp);
         });
 
+        QUnit.test("vault: Test wrong password", async function (assert) {
+            assert.expect(1);
+
+            const key = await utils.generate_key_pair();
+            const iv = utils.generate_bytes(10);
+            const salt = utils.generate_bytes(10);
+
+            const wrapper = await utils.derive_key("test", salt, 4000);
+            const exported = await utils.export_private_key(
+                key.privateKey,
+                wrapper,
+                iv
+            );
+
+            const wrong = await utils.derive_key("wrong", salt, 4000);
+            await assert.rejects(
+                utils.load_private_key(exported, wrong, utils.toBase64(iv))
+            );
+        });
+
         QUnit.test("vault: Test vault class", async function (assert) {
             assert.expect(12);
 


### PR DESCRIPTION
Raise a clear message instead of raw OperationError when entering a wrong password.