### PR TITLE
[18.0][FIX] vault: do not present exhausted inboxes as writable

### DIFF
--- a/vault/controllers/main.py
+++ b/vault/controllers/main.py
@@ -55,7 +55,7 @@ class Controller(http.Controller):
             return request.render("vault.inbox", ctx)
 
         try:
-            inbox.store_in_inbox(
+            result = inbox.store_in_inbox(
                 name,
                 secret,
                 secret_file,
@@ -70,6 +70,10 @@ class Controller(http.Controller):
             ctx["error"] = _(
                 "An error occured. Please contact the user or administrator"
             )
+            return request.render("vault.inbox", ctx)
+
+        if not result:
+            ctx["error"] = _("This link is no longer active")
             return request.render("vault.inbox", ctx)
 
         ctx["message"] = _("Successfully stored")

--- a/vault/models/vault_inbox.py
+++ b/vault/models/vault_inbox.py
@@ -43,6 +43,7 @@ class VaultInbox(models.Model):
         help="If expired the inbox can't be written using the link",
     )
     log_ids = fields.One2many("vault.inbox.log", "inbox_id", "Log", readonly=True)
+    writable = fields.Boolean(compute="_compute_writable")
 
     _sql_constraints = [
         (
@@ -51,6 +52,14 @@ class VaultInbox(models.Model):
             "No value found",
         ),
     ]
+
+    @api.depends("accesses", "expiration")
+    def _compute_writable(self):
+        now = datetime.now()
+        for rec in self:
+            rec.writable = rec.accesses > 0 and (
+                not rec.expiration or now < rec.expiration
+            )
 
     @api.depends("token")
     def _compute_inbox_link(self):

--- a/vault/tests/__init__.py
+++ b/vault/tests/__init__.py
@@ -3,6 +3,7 @@
 
 from . import (
     test_controller,
+    test_inbox,
     test_log,
     test_rights,
     test_user,

--- a/vault/tests/test_controller.py
+++ b/vault/tests/test_controller.py
@@ -98,6 +98,20 @@ class TestController(BaseCommon):
             self.assertEqual(self.inbox.secret, "secret")
             self.assertEqual(self.inbox.secret_file, b"file")
 
+            exhausted = self.env["vault.inbox"].create(
+                {
+                    "user_id": self.user.id,
+                    "name": "Exhausted",
+                    "key": "4",
+                    "iv": "1",
+                    "secret": "kept secret",
+                    "accesses": 0,
+                }
+            )
+            response = load(self.controller.vault_inbox(exhausted.token))
+            self.assertEqual(response["error"], "Invalid token")
+            self.assertEqual(exhausted.secret, "kept secret")
+
             # Test a duplicate inbox
             self.inbox.copy().token = self.inbox.token
             response = load(self.controller.vault_inbox(self.inbox.token))

--- a/vault/tests/test_inbox.py
+++ b/vault/tests/test_inbox.py
@@ -72,6 +72,32 @@ class TestShare(BaseCommon):
         self.assertEqual(inbox, model.find_inbox(inbox.token))
         self.assertEqual(model, model.find_inbox(uuid4()))
 
+    def test_writable(self):
+        model = self.env["vault.inbox"]
+        user = self.env.user
+        inbox = model.store_in_inbox(
+            name=f"Inbox {user.name}",
+            secret="secret",
+            iv="iv",
+            user=user,
+            key="key",
+            secret_file="",
+            filename="",
+        )
+
+        inbox.accesses = 5
+        self.assertTrue(inbox.writable)
+
+        inbox.accesses = 0
+        self.assertFalse(inbox.writable)
+
+        inbox.accesses = 5
+        inbox.expiration = datetime(1970, 1, 1)
+        self.assertFalse(inbox.writable)
+
+        inbox.expiration = False
+        self.assertTrue(inbox.writable)
+
     def test_send_wizard(self):
         user = self.env.user
         wiz = self.env["vault.send.wizard"].create(

--- a/vault/views/vault_inbox_views.xml
+++ b/vault/views/vault_inbox_views.xml
@@ -3,7 +3,8 @@
     <record id="view_vault_inbox_tree" model="ir.ui.view">
         <field name="model">vault.inbox</field>
         <field name="arch" type="xml">
-            <list create="false">
+            <list create="false" decoration-muted="not writable">
+                <field name="writable" column_invisible="1" />
                 <field name="name" />
                 <field name="inbox_link" widget="url" />
             </list>
@@ -15,10 +16,17 @@
         <field name="arch" type="xml">
             <form create="false">
                 <sheet>
+                    <widget
+                        name="web_ribbon"
+                        title="Readonly"
+                        bg_color="text-bg-danger"
+                        invisible="not writable"
+                    />
                     <field name="user_id" invisible="1" />
                     <field name="iv" invisible="1" />
                     <field name="key" invisible="1" />
                     <field name="filename" invisible="1" />
+                    <field name="writable" invisible="1" />
                     <group>
                         <field name="inbox_link" widget="url" />
                         <field name="name" />


### PR DESCRIPTION
An inbox that can no longer be written to (access counter at 0 or expired) still showed its writable inbox link, and submitting to it silently did nothing while the form reported 'Successfully stored'. This is misleading for received/delivered secrets which are created with accesses = 0.
    
- Add a computed 'writable' flag (accesses left and not expired) and hide the inbox link in the list and form views when it is not writable.
- Make the controller report 'This link is no longer active' when store_in_inbox performs no write instead of a false success message.

This depends on #987 