### PR TITLE
[18.0][FIX] vault_share: render share page with website context

### DIFF
--- a/vault_share/controllers/main.py
+++ b/vault_share/controllers/main.py
@@ -10,7 +10,7 @@ _logger = logging.getLogger(__name__)
 
 
 class Controller(http.Controller):
-    @http.route("/vault/share/<string:token>", type="http", auth="public")
+    @http.route("/vault/share/<string:token>", type="http", auth="public", website=True)
     def vault_share(self, token):
         ctx = {"disable_footer": True, "token": token}
         share = request.env["vault.share"].sudo()


### PR DESCRIPTION
Accessing a share link (/vault/share/<token>) raised KeyError: 'website' when the website module is installed. This fix is aligned with #984 for `vault`.