### PR TITLE
[18.0][FIX] vault_share: make share token consistent between UI and DB

### DIFF
--- a/vault_share/models/vault_share.py
+++ b/vault_share/models/vault_share.py
@@ -22,7 +22,9 @@ class VaultShare(models.Model):
         store=False,
         help="Using this link and pin people can access the secret.",
     )
-    token = fields.Char(readonly=True, required=True, default=lambda self: uuid4())
+    token = fields.Char(
+        readonly=True, required=True, copy=False, default=lambda self: str(uuid4())
+    )
     secret = fields.Char()
     secret_file = fields.Char()
     filename = fields.Char()
@@ -53,7 +55,9 @@ class VaultShare(models.Model):
     def _compute_url(self):
         base_url = self.env["ir.config_parameter"].sudo().get_param("web.base.url")
         for rec in self:
-            rec.share_link = f"{base_url}/vault/share/{rec.token}"
+            rec.share_link = (
+                f"{base_url}/vault/share/{rec.token}" if rec.token else False
+            )
 
     @api.model
     def get(self, token, ip=None):

--- a/vault_share/tests/test_share.py
+++ b/vault_share/tests/test_share.py
@@ -32,6 +32,19 @@ class TestShare(BaseCommon):
 
         cls.share = cls.env["vault.share"].create(cls.vals)
 
+    def test_token_generated_on_create(self):
+        # Fallback: a token is minted when none is supplied (e.g. code/RPC)
+        share = self.env["vault.share"].create(self.vals)
+        self.assertTrue(share.token)
+        self.assertIsInstance(share.token, str)
+        self.assertEqual(share, share.get(share.token))
+        self.assertIn(share.token, share.share_link)
+
+        # A supplied token is kept as-is (e.g. the client-generated one)
+        share = self.env["vault.share"].create({**self.vals, "token": "fixed-token"})
+        self.assertEqual(share.token, "fixed-token")
+        self.assertEqual(share, share.get("fixed-token"))
+
     @mute_logger("odoo.sql_db")
     def test_share(self):
         self.assertEqual(self.share, self.share.get(self.share.token))

--- a/vault_share/views/vault_share_views.xml
+++ b/vault_share/views/vault_share_views.xml
@@ -16,7 +16,6 @@
             <form>
                 <sheet>
                     <group>
-                        <field name="token" invisible="1" />
                         <field name="iv" invisible="1" />
                         <field name="salt" invisible="1" />
                         <field name="iterations" invisible="1" />


### PR DESCRIPTION
The server stored a different token than the one the form used to build the share link, which then always resulted in 'Invalid token'. Generate the token client-side via a string default and persist that exact value using a view readonly field with force_save, so the UI and DB always agree.