### PR TITLE
[18.0][IMP] vault: filter entries with/without content, content shown by de…

### DIFF
--- a/vault/views/menuitems.xml
+++ b/vault/views/menuitems.xml
@@ -10,7 +10,9 @@
         <field name="name">All Entries</field>
         <field name="res_model">vault.entry</field>
         <field name="view_mode">list,form</field>
-        <field name="context">{'search_default_vault': 1}</field>
+        <field
+            name="context"
+        >{'search_default_vault': 1, 'search_default_with_content': 1}</field>
         <field
             name="view_ids"
             eval="[(5,0,0),

--- a/vault/views/vault_entry_views.xml
+++ b/vault/views/vault_entry_views.xml
@@ -209,6 +209,17 @@
                     domain="[]"
                     context="{'group_by': 'vault_id'}"
                 />
+                <separator />
+                <filter
+                    string="With Content"
+                    name="with_content"
+                    domain="['|', ('field_ids', '!=', False), ('file_ids', '!=', False)]"
+                />
+                <filter
+                    string="Without Content"
+                    name="without_content"
+                    domain="['&amp;', ('field_ids', '=', False), ('file_ids', '=', False)]"
+                />
                 <searchpanel>
                     <field
                         name="vault_id"

--- a/vault/views/vault_views.xml
+++ b/vault/views/vault_views.xml
@@ -18,7 +18,8 @@
         <field name="domain">[("vault_id", "=", active_id)]</field>
         <field name="context">{
             "default_vault_id": active_id,
-            "searchpanel_default_vault_id": active_id}
+            "searchpanel_default_vault_id": active_id,
+            "search_default_with_content": 1}
         </field>
         <field name="search_view_id" ref="view_vault_entry_search" />
     </record>


### PR DESCRIPTION
…fault

Add two search filters on vault.entry: "With Content" (has at least one field or file) and "Without Content" (pure tree/organizational entries, neither field nor file of their own).

"With Content" is active by default wherever entries are listed (vault's own "Entries" smart button, and the global "All Entries" menu), so purely organizational entries no longer clutter the list by default; "Without Content" lets a user isolate them when needed.

Assisted-by: Claude Sonnet 5