### PR TITLE
[18.0][FIX] base_user_show_email: keep the login label layout classes

### DIFF
--- a/base_user_show_email/views/login_layout.xml
+++ b/base_user_show_email/views/login_layout.xml
@@ -2,7 +2,10 @@
 <odoo>
     <template id="login" inherit_id="web.login" priority="100">
         <xpath expr="//label[@for='login']" position="replace">
-            <label for="login" class="form-label">Login</label>
+            <label
+                for="login"
+                class="form-label d-flex justify-content-between"
+            >Login</label>
         </xpath>
         <xpath expr="//input[@name='login']" position="attributes">
             <attribute name="placeholder">Login</attribute>


### PR DESCRIPTION
## Problem

On the login page, the module's renamed label and the core user switcher
button end up glued together, rendering as `LoginChoose a user`.

Core renders the login label as:

```xml
<label for="login" class="form-label d-flex justify-content-between">Email</label>
```

and the user switcher portals its "Choose a user" button straight into that
element — `addons/web/static/src/core/user_switch/user_switch.xml`:

```xml
<t t-else="" t-portal="'label.form-label'">
    <button type="button" class="o_user_switch_btn btn btn-sm btn-link m-0 p-0" ...>
        Choose a user
    </button>
</t>
```

`base_user_show_email` replaces the whole label to rename it to "Login" and
drops `d-flex justify-content-between` along the way, so the portalled button
loses its spacing. The password label right below — untouched by this module —
keeps rendering correctly, which is what makes the difference visible.

The switcher only shows up once the browser has stored logins for that
database, so the glitch is only visible to returning users, which is probably
why it went unnoticed.

## Fix

Keep the layout classes core sets on the label. One-line change, no behaviour
change beyond the layout.

## Test plan

1. Install `base_user_show_email`.
2. Log in once so the user switcher stores the login, then log out.
3. Reload `/web/login`: the "Choose a user" button should sit at the right end
   of the label row, aligned the same way as "Reset password" is on the
   password label.

Same issue is present on 19.0 (the label markup and the portal target are
unchanged there).

Internal ref: https://www.adhoc.inc/odoo/project.task/71192
