### PR TITLE
[17.0][FIX] password_security: Bypass password security checks for other modules tests

### DIFF
--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -6,8 +6,9 @@
 import re
 from datetime import datetime, timedelta
 
-from odoo import _, api, fields, models
+from odoo import _, api, fields, models, modules
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools import config
 
 
 def delta_now(**kwargs):
@@ -68,6 +69,11 @@ class ResUsers(models.Model):
         return data
 
     def _check_password_policy(self, passwords):
+        if (
+            config["test_enable"]
+            and not modules.module.current_test.test_module == "password_security"
+        ):
+            return True
         result = super()._check_password_policy(passwords)
 
         for password in passwords:
@@ -114,7 +120,10 @@ class ResUsers(models.Model):
 
     def _check_password_rules(self, password):
         self.ensure_one()
-        if not password:
+        if not password or (
+            config["test_enable"]
+            and not modules.module.current_test.test_module == "password_security"
+        ):
             return True
         pwd_params = self._get_all_password_params()
         password_regex = [


### PR DESCRIPTION
In the test cases of other modules, we use sample passwords for test users. 
These tests fail when `password_security` module is installed.

@pedrobaeza @adasatorres-tecnativa can you review please

@Tecnativa